### PR TITLE
New upstream timeout defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -309,10 +309,10 @@ func (config Config) setDefaultUpstreamParams() *Config {
 		config.Connection.Upstream.SocketTimeoutSeconds = 3
 	}
 	if config.Connection.Upstream.ReadTimeoutSeconds == 0 {
-		config.Connection.Upstream.ReadTimeoutSeconds = 120
+		config.Connection.Upstream.ReadTimeoutSeconds = 10
 	}
 	if config.Connection.Upstream.IdleTimeoutSeconds == 0 {
-		config.Connection.Upstream.IdleTimeoutSeconds = 120
+		config.Connection.Upstream.IdleTimeoutSeconds = 5
 	}
 	if config.Connection.Upstream.PoolSize == 0 {
 		config.Connection.Upstream.PoolSize = 32768

--- a/config.go
+++ b/config.go
@@ -312,7 +312,7 @@ func (config Config) setDefaultUpstreamParams() *Config {
 		config.Connection.Upstream.ReadTimeoutSeconds = 10
 	}
 	if config.Connection.Upstream.IdleTimeoutSeconds == 0 {
-		config.Connection.Upstream.IdleTimeoutSeconds = 5
+		config.Connection.Upstream.IdleTimeoutSeconds = 120
 	}
 	if config.Connection.Upstream.PoolSize == 0 {
 		config.Connection.Upstream.PoolSize = 32768

--- a/config_test.go
+++ b/config_test.go
@@ -73,7 +73,7 @@ func TestDefaultUpstreamSocketTimeout(t *testing.T) {
 func TestDefaultUpstreamReadTimeout(t *testing.T) {
 	config := new(Config).setDefaultUpstreamParams()
 	got := config.Connection.Upstream.ReadTimeoutSeconds
-	want := 120
+	want := 10
 	if got != want {
 		t.Errorf("default config got %d, want %d", got, want)
 	}

--- a/integration/downstreamHttp/downstreamroundtriptimeout_test.go
+++ b/integration/downstreamHttp/downstreamroundtriptimeout_test.go
@@ -70,7 +70,7 @@ func TestServer2HangsUpOnDownstreamIfRoundTripTimeoutExceeded(t *testing.T) {
 	}
 
 	//step 5 now wait for the grace period, then re-read. the connection must now be closed.
-	//note you must read in a loop with small buffer because golang's reader has cached data
+	//note you must read in a loop with small buffer because golang's client reader in this test reads cached data
 	time.Sleep(time.Duration(grace) * time.Second)
 	for i := 0; i < 32; i++ {
 		b, err2 = c.Read(buf)

--- a/proxyhandler.go
+++ b/proxyhandler.go
@@ -153,7 +153,7 @@ func scaffoldUpstreamRequest(proxy *Proxy) *http.Request {
 	//this context is used to time out the upstream request
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	//remember the cancelFunc, we may need to call it earlier from the outside
+	//remember the cancelFunc, we may need to call it before it times out from the outside
 	proxy.Up.Atmpt.CancelFunc = cancel
 
 	//will call the cancel func in it's own goroutine after timeout seconds.


### PR DESCRIPTION
- shorter default timeouts
- new defaults for upstream timeouts and tests
- updated docs
