### PR TITLE
239

### DIFF
--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -21,7 +21,8 @@ func TestHttpClientSocketTimeout(t *testing.T) {
 				},
 			},
 		},
-		Start: time.Now(),
+		Start:             time.Now(),
+		ConnectionWatcher: ConnectionWatcher{n: 0},
 	}
 	Runner.initReloadableCert()
 

--- a/integration/j8a5.yml
+++ b/integration/j8a5.yml
@@ -1,0 +1,26 @@
+---
+connection:
+  downstream:
+    readTimeoutSeconds: 30
+    roundTripTimeoutSeconds: 60
+    idleTimeoutSeconds: 10
+    http:
+      port: 8080
+    maxBodyBytes: 65535
+  upstream:
+    socketTimeoutSeconds: 10
+    readTimeoutSeconds: 30
+    idleTimeoutSeconds: 10
+    maxAttempts: 1
+    tlsInsecureSkipVerify: true
+
+routes:
+  - path: /mse6/
+    resource: mse6
+
+resources:
+  mse6:
+    - url:
+        scheme: http://
+        host: localhost
+        port: 60083

--- a/j8acfg.yml
+++ b/j8acfg.yml
@@ -1,17 +1,17 @@
 ---
 connection:
   downstream:
-    readTimeoutSeconds: 30
-    roundTripTimeoutSeconds: 30
-    idleTimeoutSeconds: 10
+    readTimeoutSeconds: 3
+    roundTripTimeoutSeconds: 20
+    idleTimeoutSeconds: 30
     http:
       port: 8080
     maxBodyBytes: 65535
   upstream:
-    socketTimeoutSeconds: 10
+    socketTimeoutSeconds: 3
     readTimeoutSeconds: 30
     idleTimeoutSeconds: 10
-    maxAttempts: 1
+    maxAttempts: 4
     poolSize: 8
     tlsInsecureSkipVerify: true
 
@@ -45,6 +45,7 @@ routes:
     resource: mse61
   - path: /mse6/
     resource: mse6
+    policy: ab
   - path: /mse7
     transform: /mse6
     resource: mse6

--- a/j8acfg.yml
+++ b/j8acfg.yml
@@ -12,7 +12,7 @@ connection:
     readTimeoutSeconds: 30
     idleTimeoutSeconds: 10
     maxAttempts: 1
-#    poolSize: 8
+    poolSize: 8
     tlsInsecureSkipVerify: true
 
 jwt:

--- a/j8acfg.yml
+++ b/j8acfg.yml
@@ -1,18 +1,18 @@
 ---
 connection:
   downstream:
-    readTimeoutSeconds: 3
-    roundTripTimeoutSeconds: 20
-    idleTimeoutSeconds: 30
+    readTimeoutSeconds: 30
+    roundTripTimeoutSeconds: 30
+    idleTimeoutSeconds: 10
     http:
       port: 8080
     maxBodyBytes: 65535
   upstream:
-    socketTimeoutSeconds: 3
+    socketTimeoutSeconds: 10
     readTimeoutSeconds: 30
     idleTimeoutSeconds: 10
-    maxAttempts: 4
-    poolSize: 8
+    maxAttempts: 1
+#    poolSize: 8
     tlsInsecureSkipVerify: true
 
 jwt:
@@ -45,7 +45,6 @@ routes:
     resource: mse61
   - path: /mse6/
     resource: mse6
-    policy: ab
   - path: /mse7
     transform: /mse6
     resource: mse6

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -709,8 +709,9 @@ func mockRuntime() *Runtime {
 				},
 			},
 		},
-		Start:       time.Now(),
-		AcmeHandler: NewAcmeHandler(),
+		Start:             time.Now(),
+		AcmeHandler:       NewAcmeHandler(),
+		ConnectionWatcher: ConnectionWatcher{n: 0},
 	}
 
 	//we need this to add the reloadable cert.

--- a/server_test.go
+++ b/server_test.go
@@ -164,6 +164,44 @@ func TestServerInitDotDir(t *testing.T) {
 	}
 }
 
+func BenchmarkConnectionWatcher_OnStateChange(b *testing.B) {
+	cw := ConnectionWatcher{n: 0}
+	for i := 0; i < b.N; i++ {
+		cw.OnStateChange(nil, http.StateNew)
+	}
+}
+
+func TestConnectionWatcher_OnStateChange(t *testing.T) {
+	cw := ConnectionWatcher{n: 0, m: 0}
+	cw.OnStateChange(nil, http.StateNew)
+
+	if cw.Count() != 1 {
+		t.Error("count should be 1")
+	}
+
+	if cw.MaxCount() != 1 {
+		t.Error("maxcount should be 1")
+	}
+
+	cw.OnStateChange(nil, http.StateNew)
+	if cw.Count() != 2 {
+		t.Error("count should be 2")
+	}
+
+	if cw.MaxCount() != 2 {
+		t.Error("maxcount should be 2")
+	}
+
+	cw.OnStateChange(nil, http.StateClosed)
+	if cw.Count() != 1 {
+		t.Error("count should be 1")
+	}
+
+	if cw.MaxCount() != 2 {
+		t.Error("maxcount should still be 2")
+	}
+}
+
 func setupJ8a() {
 	ConfigFile = "./j8acfg.yml"
 	Boot.Add(1)

--- a/stats.go
+++ b/stats.go
@@ -12,14 +12,15 @@ import (
 )
 
 type sample struct {
-	pid         int32
-	cpuPc       float64
-	mPc         float32
-	rssBytes    uint64
-	vmsBytes    uint64
-	swapBytes   uint64
-	time        time.Time
-	openTcpCons uint64
+	pid               int32
+	cpuPc             float64
+	mPc               float32
+	rssBytes          uint64
+	vmsBytes          uint64
+	swapBytes         uint64
+	time              time.Time
+	dwnOpenTcpCons    uint64
+	dwnMaxOpenTcpCons uint64
 }
 
 type growthRate struct {
@@ -44,7 +45,8 @@ const pidMemPct = "pidMemPct"
 const pidRssBytes = "pidRssBytes"
 const pidVmsBytes = "pidVmsBytes"
 const pidSwapBytes = "pidSwapBytes"
-const pidOpenTcpCons = "pidOpenTcpCons"
+const pidDwnOpenTcpCons = "pidDwnOpenTcpCons"
+const pidDwnMaxOpenTcpCons = "pidDwnMaxOpenTcpCons"
 const serverPerformance = "server performance"
 const pcd2f = "%.2f"
 
@@ -55,7 +57,8 @@ func (s sample) log() {
 		Int32(pid, s.pid).
 		Str(pidCPUCorePct, fmt.Sprintf(pcd2f, s.cpuPc)).
 		Str(pidMemPct, fmt.Sprintf(pcd2f, s.mPc)).
-		Uint64(pidOpenTcpCons, s.openTcpCons).
+		Uint64(pidDwnOpenTcpCons, s.dwnOpenTcpCons).
+		Uint64(pidDwnMaxOpenTcpCons, s.dwnMaxOpenTcpCons).
 		Uint64(pidRssBytes, s.rssBytes).
 		Uint64(pidVmsBytes, s.vmsBytes).
 		Uint64(pidSwapBytes, s.swapBytes).
@@ -111,14 +114,15 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 
 	procStatsLock.Unlock()
 	return sample{
-		pid:         proc.Pid,
-		cpuPc:       cpuPc,
-		mPc:         mPc,
-		rssBytes:    mInfo.RSS,
-		vmsBytes:    mInfo.VMS,
-		swapBytes:   mInfo.Swap,
-		time:        time.Now(),
-		openTcpCons: rt.ConnectionWatcher.Count(),
+		pid:               proc.Pid,
+		cpuPc:             cpuPc,
+		mPc:               mPc,
+		rssBytes:          mInfo.RSS,
+		vmsBytes:          mInfo.VMS,
+		swapBytes:         mInfo.Swap,
+		time:              time.Now(),
+		dwnOpenTcpCons:    rt.ConnectionWatcher.Count(),
+		dwnMaxOpenTcpCons: rt.ConnectionWatcher.MaxCount(),
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -12,13 +12,14 @@ import (
 )
 
 type sample struct {
-	pid       int32
-	cpuPc     float64
-	mPc       float32
-	rssBytes  uint64
-	vmsBytes  uint64
-	swapBytes uint64
-	time      time.Time
+	pid         int32
+	cpuPc       float64
+	mPc         float32
+	rssBytes    uint64
+	vmsBytes    uint64
+	swapBytes   uint64
+	time        time.Time
+	openTcpCons uint64
 }
 
 type growthRate struct {
@@ -43,6 +44,7 @@ const pidMemPct = "pidMemPct"
 const pidRssBytes = "pidRssBytes"
 const pidVmsBytes = "pidVmsBytes"
 const pidSwapBytes = "pidSwapBytes"
+const pidOpenTcpCons = "pidOpenTcpCons"
 const serverPerformance = "server performance"
 const pcd2f = "%.2f"
 
@@ -53,6 +55,7 @@ func (s sample) log() {
 		Int32(pid, s.pid).
 		Str(pidCPUCorePct, fmt.Sprintf(pcd2f, s.cpuPc)).
 		Str(pidMemPct, fmt.Sprintf(pcd2f, s.mPc)).
+		Uint64(pidOpenTcpCons, s.openTcpCons).
 		Uint64(pidRssBytes, s.rssBytes).
 		Uint64(pidVmsBytes, s.vmsBytes).
 		Uint64(pidSwapBytes, s.swapBytes).
@@ -99,7 +102,7 @@ High:
 	return growthRates
 }
 
-func getSample(proc *process.Process) sample {
+func (rt *Runtime) getSample(proc *process.Process) sample {
 	procStatsLock.Lock()
 
 	cpuPc, _ := proc.Percent(time.Millisecond * cpuSampleMilliSeconds)
@@ -108,33 +111,34 @@ func getSample(proc *process.Process) sample {
 
 	procStatsLock.Unlock()
 	return sample{
-		pid:       proc.Pid,
-		cpuPc:     cpuPc,
-		mPc:       mPc,
-		rssBytes:  mInfo.RSS,
-		vmsBytes:  mInfo.VMS,
-		swapBytes: mInfo.Swap,
-		time:      time.Now(),
+		pid:         proc.Pid,
+		cpuPc:       cpuPc,
+		mPc:         mPc,
+		rssBytes:    mInfo.RSS,
+		vmsBytes:    mInfo.VMS,
+		swapBytes:   mInfo.Swap,
+		time:        time.Now(),
+		openTcpCons: rt.ConnectionWatcher.Count(),
 	}
 }
 
 //log proc samples infinite loop
-func logProcStats(proc *process.Process) {
+func (rt *Runtime) logRuntimeStats(proc *process.Process) {
 	go func() {
 		for {
-			getSample(proc).log()
+			rt.getSample(proc).log()
 			time.Sleep(time.Second * logSamplerSleepSeconds)
 		}
 	}()
 
 	go func() {
 		procHistory = make(samples, historyMaxSamples)
-		lazy := getSample(proc)
+		lazy := rt.getSample(proc)
 		for k := 0; k < historyMaxSamples; k++ {
 			procHistory[k] = lazy
 		}
 		for {
-			procHistory.append(getSample(proc))
+			procHistory.append(rt.getSample(proc))
 			time.Sleep(time.Second * historySamplerSleepSeconds)
 		}
 	}()
@@ -149,10 +153,10 @@ func logProcStats(proc *process.Process) {
 
 const uptimeMicros = "uptimeMicros"
 
-func logUptime() {
+func (rt *Runtime) logUptime() {
 	go func() {
 		for {
-			upNanos := time.Since(Runner.Start)
+			upNanos := time.Since(rt.Start)
 			if upNanos > time.Second*10 {
 				uptime := durafmt.Parse(upNanos).LimitFirstN(1).String()
 				log.Debug().

--- a/stats_test.go
+++ b/stats_test.go
@@ -11,7 +11,9 @@ func TestStats(t *testing.T) {
 	pid := os.Getpid()
 	proc, _ := process.NewProcess(int32(pid))
 
-	s := getSample(proc)
+	rt := mockRuntime()
+
+	s := rt.getSample(proc)
 	if s.pid != int32(os.Getpid()) {
 		t.Error("pid not correctly set")
 	}
@@ -31,8 +33,10 @@ func TestSamplesAppendDoNotExceedCapacity(t *testing.T) {
 	proc, _ := process.NewProcess(int32(pid))
 	var history samples = make(samples, historyMaxSamples)
 
+	rt := mockRuntime()
+
 	//now using same sample for append test, it makes the test so much faster
-	sample := getSample(proc)
+	sample := rt.getSample(proc)
 	for i := 0; i < 50; i++ {
 		t.Logf("appending %d sample", i)
 		history.append(sample)
@@ -55,7 +59,10 @@ func TestProcStatsAppendInOrder(t *testing.T) {
 	pid := int32(os.Getpid())
 	proc, _ := process.NewProcess(pid)
 	var history samples = make(samples, historyMaxSamples)
-	sample := getSample(proc)
+
+	rt := mockRuntime()
+
+	sample := rt.getSample(proc)
 
 	for i := 0; i < historyMaxSamples; i++ {
 		history.append(sample)
@@ -178,6 +185,7 @@ func TestRSSGrowthRatesInsufficientData(t *testing.T) {
 func TestLogProcStats(t *testing.T) {
 	//runtime panic test only, no assertions
 	proc, _ := process.NewProcess(int32(os.Getpid()))
-	logProcStats(proc)
+	rt := mockRuntime()
+	rt.logRuntimeStats(proc)
 	time.Sleep(time.Duration(time.Second * 3))
 }


### PR DESCRIPTION
- added connection monitor
- added pidDwnOpenCons monitoring currently open downstream TCP connections and pidDwnMaxOpenCons lifetime max value since server start
- revert j8acfg.yml commit it introduced a bug
- revert j8acfg.yml commit it introduced a bug
- new config file with 30s readtimeout and shorter config for performance tests
