### PR TITLE
244

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	github.com/andybalholm/brotli v1.0.4
 	github.com/klauspost/compress v1.15.1
+	github.com/simonmittag/procspy v0.0.3
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/miekg/dns v1.1.43 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/miekg/dns v1.1.43 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 require (
 	github.com/andybalholm/brotli v1.0.4
 	github.com/klauspost/compress v1.15.1
-	github.com/simonmittag/procspy v0.0.3
+	github.com/simonmittag/procspy v0.0.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3 h1:hdLd+gO0aciLEjk7mVn/4nnhuGhl+9QJM5xnycbQmAI=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3/go.mod h1:KwnaQv/8qFqXREe3f/+7MXWXVzaXpMCIkaaLKxLCgh4=
-github.com/simonmittag/procspy v0.0.3 h1:N7pfTmZYTafwtSnRnFMYr5Xib8CMMD9KawMfy7RxVlk=
-github.com/simonmittag/procspy v0.0.3/go.mod h1:l0JM9lRYlCWSks6n2bR8LoSXsv4E6a5jUk/tAthhTgg=
+github.com/simonmittag/procspy v0.0.4 h1:Y/sXePLWVJUxodCNLtYsMjmUnBcBSZ6BakED0CvkOAw=
+github.com/simonmittag/procspy v0.0.4/go.mod h1:l0JM9lRYlCWSks6n2bR8LoSXsv4E6a5jUk/tAthhTgg=
 github.com/simonmittag/ws v1.0.42 h1:T/NtSuIDAedeFfGct4P03G0TonoM8TjpLbWhF2GXhy8=
 github.com/simonmittag/ws v1.0.42/go.mod h1:qQ22pZZRjR7+hBJ6fCl7YFytZtLWwD75kkmhL1lY/pM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3 h1:hdLd+gO0aciLEjk7mVn/4nnhuGhl+9QJM5xnycbQmAI=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3/go.mod h1:KwnaQv/8qFqXREe3f/+7MXWXVzaXpMCIkaaLKxLCgh4=
-github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 h1:2vdAWuq0Bz3r4hu/1il3b6r40GtPu/CpOVy4mdd5u0s=
-github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67/go.mod h1:HUFk0D2ql6u0y8MaqlKQQty3NqIZGe/SvQt7D8QS5Ok=
+github.com/simonmittag/procspy v0.0.3 h1:N7pfTmZYTafwtSnRnFMYr5Xib8CMMD9KawMfy7RxVlk=
+github.com/simonmittag/procspy v0.0.3/go.mod h1:l0JM9lRYlCWSks6n2bR8LoSXsv4E6a5jUk/tAthhTgg=
 github.com/simonmittag/ws v1.0.42 h1:T/NtSuIDAedeFfGct4P03G0TonoM8TjpLbWhF2GXhy8=
 github.com/simonmittag/ws v1.0.42/go.mod h1:qQ22pZZRjR7+hBJ6fCl7YFytZtLWwD75kkmhL1lY/pM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3 h1:hdLd+gO0aciLEjk7mVn/4nnhuGhl+9QJM5xnycbQmAI=
 github.com/simonmittag/lego/v4 v4.4.1-0.20210801233615-446f36e1d8f3/go.mod h1:KwnaQv/8qFqXREe3f/+7MXWXVzaXpMCIkaaLKxLCgh4=
+github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67 h1:2vdAWuq0Bz3r4hu/1il3b6r40GtPu/CpOVy4mdd5u0s=
+github.com/simonmittag/procspy v0.0.0-20191119070947-e8cf3f846a67/go.mod h1:HUFk0D2ql6u0y8MaqlKQQty3NqIZGe/SvQt7D8QS5Ok=
 github.com/simonmittag/ws v1.0.42 h1:T/NtSuIDAedeFfGct4P03G0TonoM8TjpLbWhF2GXhy8=
 github.com/simonmittag/ws v1.0.42/go.mod h1:qQ22pZZRjR7+hBJ6fCl7YFytZtLWwD75kkmhL1lY/pM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -22,7 +22,7 @@ func TestHttpClientSocketTimeout(t *testing.T) {
 			},
 		},
 		Start:             time.Now(),
-		ConnectionWatcher: ConnectionWatcher{n: 0},
+		ConnectionWatcher: ConnectionWatcher{dwnOpenConns: 0},
 	}
 	Runner.initReloadableCert()
 

--- a/integration/j8a6.yml
+++ b/integration/j8a6.yml
@@ -22,5 +22,5 @@ resources:
   mse6:
     - url:
         scheme: http://
-        host: localhost
+        host: "[::1]"
         port: 60083

--- a/integration/j8a6.yml
+++ b/integration/j8a6.yml
@@ -10,7 +10,7 @@ connection:
   upstream:
     socketTimeoutSeconds: 10
     readTimeoutSeconds: 30
-    idleTimeoutSeconds: 10
+    idleTimeoutSeconds: 60
     maxAttempts: 1
     tlsInsecureSkipVerify: true
 

--- a/integration/j8a7.yml
+++ b/integration/j8a7.yml
@@ -1,0 +1,26 @@
+---
+connection:
+  downstream:
+    readTimeoutSeconds: 30
+    roundTripTimeoutSeconds: 60
+    idleTimeoutSeconds: 30
+    http:
+      port: 8080
+    maxBodyBytes: 65535
+  upstream:
+    socketTimeoutSeconds: 10
+    readTimeoutSeconds: 30
+    idleTimeoutSeconds: 60
+    maxAttempts: 1
+    tlsInsecureSkipVerify: true
+
+routes:
+  - path: /mse6/
+    resource: mse6
+
+resources:
+  mse6:
+    - url:
+        scheme: http://
+        host: 127.0.0.1
+        port: 60083

--- a/integration/j8a8.yml
+++ b/integration/j8a8.yml
@@ -1,0 +1,310 @@
+---
+connection:
+  downstream:
+    readTimeoutSeconds: 3
+    roundTripTimeoutSeconds: 20
+    idleTimeoutSeconds: 30
+    http:
+      port: 8083
+      redirecttls: true
+    tls:
+      port: 8443
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIEkzCCAvugAwIBAgIRANiwkh9AuRgrvYh7Y5DtWIUwDQYJKoZIhvcNAQELBQAw
+        gYExHjAcBgNVBAoTFW1rY2VydCBkZXZlbG9wbWVudCBDQTErMCkGA1UECwwic2lt
+        b25taXR0YWdAdHJvb3BlciAoU2ltb24gTWl0dGFnKTEyMDAGA1UEAwwpbWtjZXJ0
+        IHNpbW9ubWl0dGFnQHRyb29wZXIgKFNpbW9uIE1pdHRhZykwHhcNMTkwNjAxMDAw
+        MDAwWhcNMzAwNzMwMDExNDU5WjBjMScwJQYDVQQKEx5ta2NlcnQgZGV2ZWxvcG1l
+        bnQgY2VydGlmaWNhdGUxODA2BgNVBAsML3NpbW9ubWl0dGFnQE1hY0Jvb2stUHJv
+        LTE2LmxvY2FsIChTaW1vbiBNaXR0YWcpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+        MIIBCgKCAQEAsCTQ9rLTQYjIlGF7EOrTJux8E514TUoAuQ0xo1NOSssptjmDyGhb
+        8K7+A/TgdU/xlPMcJf22nNDQ2MpqpgHGlDcuXt3SmVrcsTeby1Pa81gxKp23a51B
+        8xAoHoHwXVSWdiMWk3H/Jjv/dtYL1L180neewcWvK26ANUwlzWG6BW1QVUXXNdRo
+        dmxQ1eg2S/qMBASFj6QjCsWWJiEfmz4PQpsP8q5IqCcX85BUqGO919JlE/eXEAgk
+        9Yuh61/50n39B/sPC0mU5s6vH0SPCBvz1g8SiXa8jj3jCXxa/0ZsYtAVqPe5BoRP
+        vK2q1sbKbJVr7EpmiOdKxKPHonRHasweGwIDAQABo4GiMIGfMA4GA1UdDwEB/wQE
+        AwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB8GA1UdIwQY
+        MBaAFMNEcloV4jg+eonB5omuJvQXiqiRMEkGA1UdEQRCMECCDyouamFiYmF0ZXN0
+        LmNvbYIKamFiYmEudGVzdIIJbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAA
+        AAABMA0GCSqGSIb3DQEBCwUAA4IBgQDGI3EUWPKsEOqLCpnwSlFihu8n9+g4pV3/
+        jItYhUqMBz1v8TqV2zykkJUtlfNoxrp5OAg4CG0Xr1zhqjub3teKbsNKlRpV+h04
+        4ncltpe66u4gg9RW+ww/f+J3C2yZRIX+brhDcTpdEMyfVoCV/5jeCxWf29MdFcLU
+        BfgFdEp1oe3bK/dyZc8SbUlmizyumaDOaZACihz/DKsJ+lzRdy6c3UPQgC3r72oN
+        Lx/ccpnwdeumWFs+qYOjYfrCGFXaabokdtyit4XURFngxpnPUB9jHDvkI5+/eTaB
+        SpdjJxE6x4mciyZSvshhu1v8j52+d9zUANs9+Y/v6EoCZ6byaaS4NAmTXdAWlnYb
+        hIuRRsI4gIDhJWLrACBu1Osh7ZknaLNVMt5xo3TemCkVKud3NHGbycHTUoFBuHz/
+        JOTQJ/Z1Ym3enpTAESZVcZTzS9gL62wfIfLcFvq+tVjoJZVJCcolP2fYn3U5lEiN
+        vZvs72xp4sYEOa9zhvEs/yte9c6rkU0=
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        MIIE0zCCAzugAwIBAgIQB2bsiI7SUtxu+HwBxuNtpDANBgkqhkiG9w0BAQsFADCB
+        gTEeMBwGA1UEChMVbWtjZXJ0IGRldmVsb3BtZW50IENBMSswKQYDVQQLDCJzaW1v
+        bm1pdHRhZ0B0cm9vcGVyIChTaW1vbiBNaXR0YWcpMTIwMAYDVQQDDClta2NlcnQg
+        c2ltb25taXR0YWdAdHJvb3BlciAoU2ltb24gTWl0dGFnKTAeFw0yMDA1MDEyMTE2
+        NDNaFw0zMDA1MDEyMTE2NDNaMIGBMR4wHAYDVQQKExVta2NlcnQgZGV2ZWxvcG1l
+        bnQgQ0ExKzApBgNVBAsMInNpbW9ubWl0dGFnQHRyb29wZXIgKFNpbW9uIE1pdHRh
+        ZykxMjAwBgNVBAMMKW1rY2VydCBzaW1vbm1pdHRhZ0B0cm9vcGVyIChTaW1vbiBN
+        aXR0YWcpMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzivKfp5OiWpT
+        362cVgbw9DBqwMP0pO32aP79Y4UYeAxCfaWQDdqQEatBdraShtZcvUX8vZ9jvgHE
+        oGMGSJb/DIVRxIDfhdvhh4qGQgbbSLwDkfLJTkpGMdONa/5yDC54fNZjF095YZn7
+        iPmsFbvYUfTwpM8qrP+jZzobByrTO4rG3Ps080gIR08RCA0E+uLg58rTpnsdBKZ0
+        K2uuE4B4lVAs2AeS4KPMrH/rnCjSZz4KRwnaGqh+wiAjO0PHAfrbrhNsFB6P1/Zk
+        Cqzclj3TXdkMDaXhSvt0qJPEpNIPQMkvj9GROom7hExZUT7t7LPOZwODtiR2VjM3
+        DDehfLqpNPRrxU3aOR7b4lFVtEL1+9NXKc3rnR5T2xPVVvBxx8FqYAxFmQtkGqpA
+        YlRxImBONBreIr5/fdkr5xqd/S0s1pb8ubuK7x5COfqf0Mv++j+UjMptBQ3kYvOh
+        tNrbnEI1q/7kvHNB8ETtJ4hqXikl9EHMYWdOo4nyGd4P8jo9jmGVAgMBAAGjRTBD
+        MA4GA1UdDwEB/wQEAwICBDASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTD
+        RHJaFeI4PnqJweaJrib0F4qokTANBgkqhkiG9w0BAQsFAAOCAYEAb+K3HO2AlDed
+        S2yT7GnxD75Hcjnv1tMvMIlh1EOmRMHrzbsi7jv3Z7SDe2R5s1qRku3nxbVWj8i8
+        oRBi5GeRE+q/HkVloi4WPmgFGxUUbkWszAFSSGN5TAs72e5sCG/wMyEa0Gj8cOO1
+        dK5SH3thP8+OjSpgQXToYfOimILlk7Hj7EgKE5Y8YX8UV+41LhGkzeK2UX9dBZn1
+        of9qBc0dAQVlAA/O3dOgXorgiDbNT38cjignWEwVYzjeuJCYB91Ixf0CfHJZKHZR
+        ZCdIAHTJqW1tx7vsbrcl0PVAMgm+rkHLL0Dh9cp4fvONXWygVSjbqKM1s8UI9bFA
+        bWU5Z3MhEn25wZCXLQDIq0uC+FwCxyS9e/exL4wmYpCLmRKVCp2gUa78Rlr/FJNa
+        H9kfvP41Ya+fLzDWNKAlYQgizpZJmZuhPZu7O6n0UusaI+0WTKblCFUQJkx4aKEv
+        io8QmLzoedmvVpO9Zp44Lyabmc7VnjoYTOcZczx4ECwEdKH/jswc
+        -----END CERTIFICATE-----
+      key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCwJND2stNBiMiU
+        YXsQ6tMm7HwTnXhNSgC5DTGjU05Kyym2OYPIaFvwrv4D9OB1T/GU8xwl/bac0NDY
+        ymqmAcaUNy5e3dKZWtyxN5vLU9rzWDEqnbdrnUHzECgegfBdVJZ2IxaTcf8mO/92
+        1gvUvXzSd57Bxa8rboA1TCXNYboFbVBVRdc11Gh2bFDV6DZL+owEBIWPpCMKxZYm
+        IR+bPg9Cmw/yrkioJxfzkFSoY73X0mUT95cQCCT1i6HrX/nSff0H+w8LSZTmzq8f
+        RI8IG/PWDxKJdryOPeMJfFr/Rmxi0BWo97kGhE+8rarWxspslWvsSmaI50rEo8ei
+        dEdqzB4bAgMBAAECggEAc9nDFn7HM3MjeXQj3RyVhCRF9yC63xqtHwjufN1twQOe
+        i5uIcWcyETsHFtMYThAmdDDxcotMcBdnRS7cthK06QbiGMMMoJCCVoyciz674xE+
+        RSk2WjE0DwmxWV9dGAVqcIjjcFap2hvcCez+Gw4F6ueCIzBB5e7npCZRNqPwFWCY
+        /og06ypz/4LHXFNatvRJC3qhWFwFo1bVC1ycZmc5RQ4IHeQHzi6oCJhSRdCbM7Q9
+        7fQhmjtcw0pxvJTVV+XP7tTf9iDDwgi/Le2iEqNQ1D6c4+nYAGYj2D3919oUYnyv
+        tnznZ2GTibIyP6kl4L79ChRz0JGBzraKH7aJh9H1AQKBgQDS0xd8RNLJ5hkwPitt
+        x/4RNlobGGZqqvQiCKkaDvnc1E1eKR3rVlxH17/ccA/qs0vcoFDPbGyRa/OgD7p5
+        Ro3R+EPDFoFq1KMP4SRoGcDgrNKHQ3o06sUngmtUUP28G+DUQm46xW7cnQrvvNiK
+        f9MMfeNH+tAPtssZh0HNKJa9fwKBgQDV40peDqh9b4Ag+mfiHIJGuwTN8LMvKRqr
+        N5dVirl2BDYMwF6JflIwIwjBZq7ah3NsT5/Yd+nuY+ux/pO4iU5jMbTtoAOv2dc7
+        VKpqNTaQdJhta5OlOdBSP5iXj4siVCMIFL1jz8JtWuXX4hUtbliG6ICZTH2/5ivG
+        faPiOhAlZQKBgQCp941jnojiRSPhhP22UBpA/jS+y3kmXhTcq2bJn3FJ289ULon0
+        hXd4ZDRGIAJ1EYADqyv7TkppI0MStBt+UqdbtG/NBIPqAOxFjRmw47JgcHR6oKgR
+        qYSxSbAGFhW6Zi9ocPY1Y57xNZrvlKxvXIZl98gY69h6EsDDIAyoviRpOQKBgC0g
+        Rjlv+EZ2tt6+VhqTjzzjClF03ikuD+1dzjUDDrwCiXDJSWjS2P5E9fzv8CY0+7o3
+        Vm8yZY2hUUH9hycg+QPeoeCcqQp5+HoRE99SmM+DegFj+AOdHgGsX0Jiy6UTgUyc
+        K5UaaVfvHJ0emv85z72u4ir1w3YwVr4LFf+N5ogtAoGAHODQpVC7sg+nlbeSKsPf
+        RbULfOG4YD5pHszNM+nCjNWs00ofJoZOFA64qXwTIc4Vrh8JLiwAkXiTGYM2guv5
+        Qnp+HbFi/tAc+rQu4SGBaVIglnIj7jFNdgJOb68Vw/L9v2jW1Y8VoAC0eCRWpHud
+        GsMkN4GFOfQKoBI/aCXn4DM=
+        -----END PRIVATE KEY-----
+  upstream:
+    socketTimeoutSeconds: 30
+    readTimeoutSeconds: 120
+    idleTimeoutSeconds: 120
+    maxAttempts: 1
+    tlsInsecureSkipVerify: yes
+policies:
+  ab:
+    - label: green
+      weight: 0.8
+    - label: blue
+      weight: 0.2
+routes:
+  - path: "/about"
+    resource: about
+  - path: "/mse6/some"
+    resource: mse61
+  - path: "/mse6/"
+    resource: mse6
+  - path: "/s01"
+    resource: s01
+  - path: "/s02"
+    resource: s02
+  - path: "/s03"
+    resource: s03
+  - path: "/s04"
+    resource: s04
+  - path: "/s05"
+    resource: s05
+  - path: "/s06"
+    resource: s06
+  - path: "/s07"
+    resource: s07
+  - path: "/s08"
+    resource: s08
+  - path: "/s09"
+    resource: s09
+  - path: "/s10"
+    resource: s10
+  - path: "/s11"
+    resource: s11
+  - path: "/s12"
+    resource: s12
+  - path: "/s13"
+    resource: s13
+  - path: "/s14"
+    resource: s14
+  - path: "/s15"
+    resource: s15
+  - path: "/s16"
+    resource: s16
+  - path: "/badip"
+    resource: badip
+  - path: "/baddns"
+    resource: baddns
+  - path: "/badremote"
+    resource: badremote
+  - path: "/badlocal"
+    resource: badlocal
+  - path: /badssl
+    resource: badssl
+  - path: "/websocket"
+    transform: "/mse6/websocket"
+    resource: websocket
+  - path: "/websocketdown"
+    resource: websocketdown
+  - path: /websocketsecure
+    transform: /badssl
+    resource: websocketsecure
+  - path: /todos
+    resource: jsonplaceholder
+resources:
+  badssl:
+    - url:
+        scheme: https
+        host: localhost
+        port: 60101
+  badip:
+    - url:
+        scheme: http
+        host: 10.247.13.14
+        port: 29471
+  baddns:
+    - url:
+        scheme: http
+        host: kajsdkfj23848392sdfjsj332jkjkjdkshhhhimnotahost.com
+        port: 29471
+  badremote:
+    - url:
+        scheme: http
+        host: google.com
+        port: 29471
+  badlocal:
+    - url:
+        scheme: http
+        host: localhost
+        port: 29471
+  mse61:
+    - url:
+        scheme: 'http:'
+        host: localhost
+        port: 60083
+  mse6:
+    - labels:
+        - green
+      url:
+        scheme: http://
+        host: localhost
+        port: 60083
+    - labels:
+        - blue
+      url:
+        host: localhost
+        port: 60084
+  s01:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60085
+  s02:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60086
+  s03:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60087
+  s04:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60088
+  s05:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60089
+  s06:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60090
+  s07:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60091
+  s08:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60092
+  s09:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60093
+  s10:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60094
+  s11:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60095
+  s12:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60096
+  s13:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60097
+  s14:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60098
+  s15:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60099
+  s16:
+    - url:
+        scheme: http
+        host: localhost
+        port: 60100
+  websocket:
+    - url:
+        scheme: ws
+        host: localhost
+        port: 60083
+  websocketdown:
+    - url:
+        scheme: ws
+        host: 10.247.13.14
+        port: 29471
+  websocketsecure:
+    - url:
+        scheme: wss
+        host: localhost
+        port: 60101
+  jsonplaceholder:
+    - url:
+        scheme: https
+        host: jsonplaceholder.typicode.com
+        port: 443

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -696,6 +696,39 @@ func mockRuntime() *Runtime {
 						},
 					},
 				},
+				"ipv4Resource": {
+					ResourceMapping{
+						Name:   "ipv4Resource",
+						Labels: nil,
+						URL: URL{
+							Scheme: "http",
+							Host:   "127.0.0.1",
+							Port:   8084,
+						},
+					},
+				},
+				"ipv6Resource": {
+					ResourceMapping{
+						Name:   "ipv6Resource",
+						Labels: nil,
+						URL: URL{
+							Scheme: "http",
+							Host:   "[::1]",
+							Port:   8084,
+						},
+					},
+				},
+				"ipv6Resource2": {
+					ResourceMapping{
+						Name:   "ipv6Resource",
+						Labels: nil,
+						URL: URL{
+							Scheme: "http",
+							Host:   "::1",
+							Port:   8085,
+						},
+					},
+				},
 			},
 			Routes: []Route{
 				{

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -711,7 +711,7 @@ func mockRuntime() *Runtime {
 		},
 		Start:             time.Now(),
 		AcmeHandler:       NewAcmeHandler(),
-		ConnectionWatcher: ConnectionWatcher{n: 0},
+		ConnectionWatcher: ConnectionWatcher{dwnOpenConns: 0},
 	}
 
 	//we need this to add the reloadable cert.

--- a/server.go
+++ b/server.go
@@ -127,8 +127,8 @@ func (cw *ConnectionWatcher) AddUp(c int64) {
 	atomic.AddInt64(&cw.upOpenConns, c)
 }
 
-func (cw *ConnectionWatcher) SetUp(c int64) {
-	atomic.StoreInt64(&cw.upOpenConns, c)
+func (cw *ConnectionWatcher) SetUp(c uint64) {
+	atomic.StoreInt64(&cw.upOpenConns, int64(c))
 }
 
 func (cw *ConnectionWatcher) UpdateMaxUp(c uint64) {

--- a/server.go
+++ b/server.go
@@ -74,8 +74,10 @@ func (r *ReloadableCert) triggerInit() error {
 }
 
 type ConnectionWatcher struct {
-	n int64
-	m int64
+	dwnOpenConns    int64
+	dwnMaxOpenConns int64
+	upOpenConns     int64
+	upMaxOpenConns  int64
 }
 
 // OnStateChange records open connections in response to connection
@@ -84,34 +86,55 @@ type ConnectionWatcher struct {
 func (cw *ConnectionWatcher) OnStateChange(conn net.Conn, state http.ConnState) {
 	switch state {
 	case http.StateNew:
-		cw.Add(1)
+		cw.AddDwn(1)
 	case http.StateHijacked, http.StateClosed:
-		cw.Add(-1)
+		cw.AddDwn(-1)
 	}
-	c := cw.Count()
-	if c > cw.MaxCount() {
-		cw.SetMax(int64(c))
-	}
+	cw.UpdateMaxDwn(cw.DwnCount())
 }
 
 // Count returns the number of connections at the time
 // the call.
-func (cw *ConnectionWatcher) Count() uint64 {
-	return uint64(atomic.LoadInt64(&cw.n))
+func (cw *ConnectionWatcher) DwnCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.dwnOpenConns))
 }
 
-func (cw *ConnectionWatcher) MaxCount() uint64 {
-	return uint64(atomic.LoadInt64(&cw.m))
+func (cw *ConnectionWatcher) DwnMaxCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.dwnMaxOpenConns))
 }
 
 // Add adds c to the number of active connections.
-func (cw *ConnectionWatcher) Add(c int64) {
-	atomic.AddInt64(&cw.n, c)
+func (cw *ConnectionWatcher) AddDwn(c int64) {
+	atomic.AddInt64(&cw.dwnOpenConns, c)
 }
 
 // Sets the maximum number of active connections observed
-func (cw *ConnectionWatcher) SetMax(c int64) {
-	atomic.StoreInt64(&cw.m, c)
+func (cw *ConnectionWatcher) UpdateMaxDwn(c uint64) {
+	if c > cw.DwnMaxCount() {
+		atomic.StoreInt64(&cw.dwnMaxOpenConns, int64(c))
+	}
+}
+
+func (cw *ConnectionWatcher) UpCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.upOpenConns))
+}
+
+func (cw *ConnectionWatcher) UpMaxCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.upMaxOpenConns))
+}
+
+func (cw *ConnectionWatcher) AddUp(c int64) {
+	atomic.AddInt64(&cw.upOpenConns, c)
+}
+
+func (cw *ConnectionWatcher) SetUp(c int64) {
+	atomic.StoreInt64(&cw.upOpenConns, c)
+}
+
+func (cw *ConnectionWatcher) UpdateMaxUp(c uint64) {
+	if c > cw.UpMaxCount() {
+		atomic.StoreInt64(&cw.upMaxOpenConns, int64(c))
+	}
 }
 
 //Runner is the Live environment of the server
@@ -168,7 +191,7 @@ func BootStrap() {
 		Config:            *config,
 		Start:             time.Now(),
 		AcmeHandler:       NewAcmeHandler(),
-		ConnectionWatcher: ConnectionWatcher{n: 0},
+		ConnectionWatcher: ConnectionWatcher{dwnOpenConns: 0},
 	}
 	Runner.
 		initCacheDir().

--- a/server_test.go
+++ b/server_test.go
@@ -165,39 +165,39 @@ func TestServerInitDotDir(t *testing.T) {
 }
 
 func BenchmarkConnectionWatcher_OnStateChange(b *testing.B) {
-	cw := ConnectionWatcher{n: 0}
+	cw := ConnectionWatcher{dwnOpenConns: 0}
 	for i := 0; i < b.N; i++ {
 		cw.OnStateChange(nil, http.StateNew)
 	}
 }
 
 func TestConnectionWatcher_OnStateChange(t *testing.T) {
-	cw := ConnectionWatcher{n: 0, m: 0}
+	cw := ConnectionWatcher{dwnOpenConns: 0, dwnMaxOpenConns: 0}
 	cw.OnStateChange(nil, http.StateNew)
 
-	if cw.Count() != 1 {
+	if cw.DwnCount() != 1 {
 		t.Error("count should be 1")
 	}
 
-	if cw.MaxCount() != 1 {
+	if cw.DwnMaxCount() != 1 {
 		t.Error("maxcount should be 1")
 	}
 
 	cw.OnStateChange(nil, http.StateNew)
-	if cw.Count() != 2 {
+	if cw.DwnCount() != 2 {
 		t.Error("count should be 2")
 	}
 
-	if cw.MaxCount() != 2 {
+	if cw.DwnMaxCount() != 2 {
 		t.Error("maxcount should be 2")
 	}
 
 	cw.OnStateChange(nil, http.StateClosed)
-	if cw.Count() != 1 {
+	if cw.DwnCount() != 1 {
 		t.Error("count should be 1")
 	}
 
-	if cw.MaxCount() != 2 {
+	if cw.DwnMaxCount() != 2 {
 		t.Error("maxcount should still be 2")
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -61,7 +61,7 @@ const pcd2f = "%.2f"
 const rssMemIncrease = "RSS memory increase for previous %s with high factor >=%s, monitor actively."
 
 func (s sample) log() {
-	log.Debug().
+	log.Warn().
 		Int32(pid, s.pid).
 		Str(pidCPUCorePct, fmt.Sprintf(pcd2f, s.cpuPc)).
 		Str(pidMemPct, fmt.Sprintf(pcd2f, s.mPc)).

--- a/stats.go
+++ b/stats.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"runtime/pprof"
+	"strings"
 	"sync"
 	"time"
 )
@@ -184,7 +185,9 @@ func (rt *Runtime) LookUpResourceIps() map[string][]net.IP {
 	for _, v := range rt.Resources {
 		for _, r := range v {
 			is := make([]net.IP, 1)
-			is[0] = net.ParseIP(r.URL.Host)
+			h := strings.TrimLeft(r.URL.Host, "[")
+			h = strings.TrimRight(h, "]")
+			is[0] = net.ParseIP(h)
 			if is[0] == nil {
 				is, _ = net.LookupIP(r.URL.Host)
 			}

--- a/stats.go
+++ b/stats.go
@@ -5,6 +5,8 @@ import (
 	"github.com/hako/durafmt"
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/process"
+	"github.com/simonmittag/procspy"
+	"net"
 	"os"
 	"runtime/pprof"
 	"sync"
@@ -12,16 +14,18 @@ import (
 )
 
 type sample struct {
-	pid               int32
-	cpuPc             float64
-	mPc               float32
-	rssBytes          uint64
-	vmsBytes          uint64
-	swapBytes         uint64
-	time              time.Time
-	dwnOpenTcpCons    uint64
-	dwnMaxOpenTcpCons uint64
-	threads           int
+	pid                int32
+	cpuPc              float64
+	mPc                float32
+	rssBytes           uint64
+	vmsBytes           uint64
+	swapBytes          uint64
+	time               time.Time
+	dwnOpenTcpConns    uint64
+	dwnMaxOpenTcpConns uint64
+	upOpenTcpConns     uint64
+	upMaxOpenTcpConns  uint64
+	threads            int
 }
 
 type growthRate struct {
@@ -48,6 +52,8 @@ const pidVmsBytes = "pidVmsBytes"
 const pidSwapBytes = "pidSwapBytes"
 const pidDwnOpenTcpConns = "pidDwnOpenTcpConns"
 const pidDwnMaxOpenTcpConns = "pidDwnMaxOpenTcpConns"
+const pidUpOpenTcpConns = "pidUpOpenTcpConns"
+const pidUpMaxOpenTcpConns = "pidUpMaxOpenTcpConns"
 const pidOSThreads = "pidOSThreads"
 const serverPerformance = "server performance"
 const pcd2f = "%.2f"
@@ -59,8 +65,10 @@ func (s sample) log() {
 		Int32(pid, s.pid).
 		Str(pidCPUCorePct, fmt.Sprintf(pcd2f, s.cpuPc)).
 		Str(pidMemPct, fmt.Sprintf(pcd2f, s.mPc)).
-		Uint64(pidDwnOpenTcpConns, s.dwnOpenTcpCons).
-		Uint64(pidDwnMaxOpenTcpConns, s.dwnMaxOpenTcpCons).
+		Uint64(pidDwnOpenTcpConns, s.dwnOpenTcpConns).
+		Uint64(pidDwnMaxOpenTcpConns, s.dwnMaxOpenTcpConns).
+		Uint64(pidUpOpenTcpConns, s.upOpenTcpConns).
+		Uint64(pidUpMaxOpenTcpConns, s.upMaxOpenTcpConns).
 		Uint64(pidRssBytes, s.rssBytes).
 		Uint64(pidVmsBytes, s.vmsBytes).
 		Uint64(pidSwapBytes, s.swapBytes).
@@ -112,22 +120,52 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 	procStatsLock.Lock()
 
 	var threadProfile = pprof.Lookup("threadcreate")
+
 	cpuPc, _ := proc.Percent(time.Millisecond * cpuSampleMilliSeconds)
 	mPc, _ := proc.MemoryPercent()
 	mInfo, _ := proc.MemoryInfo()
 
+	cs, e := procspy.Connections(true)
+	if e != nil {
+		_ = e
+	} else {
+		d := 0
+
+	UpConn:
+		for c := cs.Next(); c != nil; c = cs.Next() {
+			if c.PID == uint(proc.Pid) {
+				for _, v := range rt.Config.Resources {
+					for _, r := range v {
+						if c.RemotePort == r.URL.Port {
+							ips, _ := net.LookupIP(r.URL.Host)
+							for _, ip := range ips {
+								if ip.Equal(c.RemoteAddress) {
+									d++
+									continue UpConn
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		rt.ConnectionWatcher.SetUp(int64(d))
+	}
+
 	procStatsLock.Unlock()
 	return sample{
-		pid:               proc.Pid,
-		cpuPc:             cpuPc,
-		mPc:               mPc,
-		rssBytes:          mInfo.RSS,
-		vmsBytes:          mInfo.VMS,
-		swapBytes:         mInfo.Swap,
-		time:              time.Now(),
-		dwnOpenTcpCons:    rt.ConnectionWatcher.Count(),
-		dwnMaxOpenTcpCons: rt.ConnectionWatcher.MaxCount(),
-		threads:           threadProfile.Count(),
+		pid:                proc.Pid,
+		cpuPc:              cpuPc,
+		mPc:                mPc,
+		rssBytes:           mInfo.RSS,
+		vmsBytes:           mInfo.VMS,
+		swapBytes:          mInfo.Swap,
+		time:               time.Now(),
+		dwnOpenTcpConns:    rt.ConnectionWatcher.DwnCount(),
+		dwnMaxOpenTcpConns: rt.ConnectionWatcher.DwnMaxCount(),
+		upOpenTcpConns:     rt.ConnectionWatcher.UpCount(),
+		upMaxOpenTcpConns:  rt.ConnectionWatcher.UpMaxCount(),
+		threads:            threadProfile.Count(),
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -125,8 +125,9 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 	mPc, _ := proc.MemoryPercent()
 	mInfo, _ := proc.MemoryInfo()
 
-	cs, e := procspy.Connections(true)
+	cs, e := rt.FindUpConns()
 	if e != nil {
+		//if this fails, skip upconns and continue with other sample data.
 		_ = e
 	} else {
 		d := rt.CountUpConns(proc, cs, rt.LookUpResourceIps())
@@ -149,6 +150,11 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 		upMaxOpenTcpConns:  rt.ConnectionWatcher.UpMaxCount(),
 		threads:            threadProfile.Count(),
 	}
+}
+
+func (rt *Runtime) FindUpConns() (procspy.ConnIter, error) {
+	cs, e := procspy.Connections(true)
+	return cs, e
 }
 
 func (rt *Runtime) CountUpConns(proc *process.Process, cs procspy.ConnIter, ips map[string][]net.IP) int {

--- a/stats.go
+++ b/stats.go
@@ -61,7 +61,7 @@ const pcd2f = "%.2f"
 const rssMemIncrease = "RSS memory increase for previous %s with high factor >=%s, monitor actively."
 
 func (s sample) log() {
-	log.Warn().
+	log.Debug().
 		Int32(pid, s.pid).
 		Str(pidCPUCorePct, fmt.Sprintf(pcd2f, s.cpuPc)).
 		Str(pidMemPct, fmt.Sprintf(pcd2f, s.mPc)).

--- a/stats.go
+++ b/stats.go
@@ -135,6 +135,7 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 		rt.ConnectionWatcher.SetUp(uint64(d))
 		rt.ConnectionWatcher.UpdateMaxUp(uint64(d))
 	}
+	_ = cs
 
 	procStatsLock.Unlock()
 	return sample{

--- a/stats.go
+++ b/stats.go
@@ -161,20 +161,20 @@ func (rt *Runtime) CountUpConns(proc *process.Process, cs procspy.ConnIter, ips 
 	d := 0
 UpConn:
 	for c := cs.Next(); c != nil; c = cs.Next() {
-		if c.PID == uint(proc.Pid) {
-			for _, v := range rt.Config.Resources {
-				for _, r := range v {
-					if c.RemotePort == r.URL.Port {
-						for _, ip := range ips[r.URL.Host] {
-							if ip.Equal(c.RemoteAddress) {
-								d++
-								continue UpConn
-							}
+		//if c.PID == uint(proc.Pid) {
+		for _, v := range rt.Config.Resources {
+			for _, r := range v {
+				if c.RemotePort == r.URL.Port {
+					for _, ip := range ips[r.URL.Host] {
+						if ip.Equal(c.RemoteAddress) {
+							d++
+							continue UpConn
 						}
 					}
 				}
 			}
 		}
+		//}
 	}
 	return d
 }

--- a/stats.go
+++ b/stats.go
@@ -161,20 +161,20 @@ func (rt *Runtime) CountUpConns(proc *process.Process, cs procspy.ConnIter, ips 
 	d := 0
 UpConn:
 	for c := cs.Next(); c != nil; c = cs.Next() {
-		//if c.PID == uint(proc.Pid) {
-		for _, v := range rt.Config.Resources {
-			for _, r := range v {
-				if c.RemotePort == r.URL.Port {
-					for _, ip := range ips[r.URL.Host] {
-						if ip.Equal(c.RemoteAddress) {
-							d++
-							continue UpConn
+		if c.PID == uint(proc.Pid) {
+			for _, v := range rt.Config.Resources {
+				for _, r := range v {
+					if c.RemotePort == r.URL.Port {
+						for _, ip := range ips[r.URL.Host] {
+							if ip.Equal(c.RemoteAddress) {
+								d++
+								continue UpConn
+							}
 						}
 					}
 				}
 			}
 		}
-		//}
 	}
 	return d
 }

--- a/stats.go
+++ b/stats.go
@@ -149,7 +149,8 @@ func (rt *Runtime) getSample(proc *process.Process) sample {
 				}
 			}
 		}
-		rt.ConnectionWatcher.SetUp(int64(d))
+		rt.ConnectionWatcher.SetUp(uint64(d))
+		rt.ConnectionWatcher.UpdateMaxUp(uint64(d))
 	}
 
 	procStatsLock.Unlock()

--- a/stats_test.go
+++ b/stats_test.go
@@ -189,3 +189,10 @@ func TestLogProcStats(t *testing.T) {
 	rt.logRuntimeStats(proc)
 	time.Sleep(time.Duration(time.Second * 3))
 }
+
+func BenchmarkRuntime_FindUpConns(b *testing.B) {
+	rt := mockRuntime()
+	for i := 0; i < b.N; i++ {
+		rt.FindUpConns()
+	}
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -190,6 +190,33 @@ func TestLogProcStats(t *testing.T) {
 	time.Sleep(time.Duration(time.Second * 3))
 }
 
+func TestRuntime_LookUpResourceIps(t *testing.T) {
+	rt := mockRuntime()
+	ips := rt.LookUpResourceIps()
+
+	got1 := ips["localhost"][0].String()
+	want1 := "::1"
+	want11 := "127.0.0.1"
+	if got1 != want1 && got1 != want11 {
+		t.Errorf("invalid ip lookup for host, want %v, got %v", want1, got1)
+	}
+	got2 := ips["127.0.0.1"][0].String()
+	want2 := "127.0.0.1"
+	if got2 != want2 {
+		t.Errorf("invalid ip lookup for ipv4, want %v, got %v", want2, got2)
+	}
+	got3 := ips["[::1]"][0].String()
+	want3 := "::1"
+	if got3 != want3 {
+		t.Errorf("invalid ip lookup for ipv6, want %v, got %v", want3, got3)
+	}
+	got4 := ips["::1"][0].String()
+	want4 := "::1"
+	if got4 != want4 {
+		t.Errorf("invalid ip lookup for ipv6, want %v, got %v", want4, got4)
+	}
+}
+
 func BenchmarkRuntime_FindUpConns(b *testing.B) {
 	rt := mockRuntime()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
- added procspy to monitor upstream connections. needs refactor it looks up DNS too often
- updating max up conns
- refactored
- refactored, added Benchmark for FindUpConns. This is very slow on the mac as it is in p0d and takes up to 2 mins in the background for 4096C. May be because of netstat on mac, but needs better benchmark before release.
- updated to experimental procspy
- updated to v0.0.4 procspy. added more sample config. re-test now that procspy is working
- server stats now log warn
- server stats now log debug again
- server stats now log debug again
- 60s upstream idle timeout recommded to measure conns
- sample config for localhost ipv4 upstream
