### PR TITLE
Add fields for ACME registration:

### DIFF
--- a/acmehandler.go
+++ b/acmehandler.go
@@ -9,18 +9,19 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/simonmittag/lego/v4/certcrypto"
-	"github.com/simonmittag/lego/v4/certificate"
-	"github.com/simonmittag/lego/v4/challenge/http01"
-	"github.com/simonmittag/lego/v4/lego"
-	"github.com/simonmittag/lego/v4/registration"
 	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/simonmittag/lego/v4/certcrypto"
+	"github.com/simonmittag/lego/v4/certificate"
+	"github.com/simonmittag/lego/v4/challenge/http01"
+	"github.com/simonmittag/lego/v4/lego"
+	"github.com/simonmittag/lego/v4/registration"
 )
 
 const acmeChallenge = "/.well-known/acme-challenge/"
@@ -251,7 +252,7 @@ func (runtime *Runtime) fetchAcmeCertAndKey(url string) error {
 	}
 
 	//we always register because it's safer than to cache credentials
-	myUser.Registration, e = client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
+	myUser.Registration, e = client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: runtime.Connection.Downstream.Tls.Acme.AcceptTOS})
 	if e != nil {
 		return e
 	}

--- a/config.go
+++ b/config.go
@@ -202,7 +202,6 @@ func (config Config) validateHTTPConfig() *Config {
 
 const wildcardDomainPrefix = "*."
 const dot = "."
-const noreply = "noreply@"
 
 func (config Config) validateAcmeConfig() *Config {
 	acmeProvider := len(config.Connection.Downstream.Tls.Acme.Provider) > 0
@@ -252,8 +251,6 @@ func (config Config) validateAcmeConfig() *Config {
 				config.panic(fmt.Sprintf("ACME domain validation does not support domains ending with '.', was %s", domain))
 			}
 		}
-
-		config.Connection.Downstream.Tls.Acme.Email = noreply + config.Connection.Downstream.Tls.Acme.Domains[0]
 	}
 
 	if acmeProvider {

--- a/config_test.go
+++ b/config_test.go
@@ -272,18 +272,17 @@ func TestValidateAcmeEmail(t *testing.T) {
 				Http: Http{Port: 80},
 				Tls: Tls{
 					Acme: Acme{
-						Domains:  []string{"adyntest.com"},
-						Provider: "letsencrypt"},
+						Domains:   []string{"adyntest.com"},
+						Provider:  "letsencrypt",
+						Email:     "noreply@example.org",
+						AcceptTOS: true,
+					},
 				},
 			},
 		},
 	}
 
 	config = config.validateAcmeConfig()
-
-	if config.Connection.Downstream.Tls.Acme.Email != "noreply@adyntest.com" {
-		t.Errorf("acme email not properly populated")
-	}
 }
 
 //TestValidateAcmeDomainInvalidLeadingDotFails

--- a/connection.go
+++ b/connection.go
@@ -60,8 +60,11 @@ type Acme struct {
 	// Domain
 	Domains []string
 
-	// Email for registration. Auto generated from domain.
+	// Email for registration.
 	Email string
+
+	// Accept ACME TOS
+	AcceptTOS bool
 }
 
 // Upstream connection params for remote servers that are being proxied

--- a/integration/j8a4.yml
+++ b/integration/j8a4.yml
@@ -11,6 +11,8 @@ connection:
       port: 443
       acme:
         provider: letsencrypt
+        email: noreply@example.org
+        acceptTOS: true
         domains:
           - api.adyntest.com
           - adyntest.com


### PR DESCRIPTION
Added email address and TOS agreement fields.

These should be specified in the j8acfg.yml file in format:

connection:
  downstream:
    tls:
      acme:
        provider: letsencrypt
        email: noreply@example.org
        acceptTOS: true
        domains:
          - example.org

Probably needs extra tests, but currently works.

I've verified that it receives an error message from the ACME provider if the terms of service are not accepted,
but there is currently no validation of the email address. The email address is currently just passed to the ACME
provider for validation.

gofmt also re-ordered the imports in acmehandler.go. It's probably worth running gofmt across the entire code-base to prevent these changes polluting future PRs.