### PR TITLE
78

### DIFF
--- a/abouthandler.go
+++ b/abouthandler.go
@@ -92,21 +92,21 @@ var httpResponses = map[int]string{
 	599: "network connect timeout error",
 }
 
-//AboutResponse exposes standard environment
+// AboutResponse exposes standard environment
 type AboutResponse struct {
 	J8a      string
 	ServerID string
 	Version  string
 }
 
-//StatusCodeResponse defines a JSON structure for a canned HTTP response
+// StatusCodeResponse defines a JSON structure for a canned HTTP response
 type StatusCodeResponse struct {
 	AboutResponse
 	Code    int
 	Message string
 }
 
-//AsJSON renders the status Code response into a JSON string as []byte
+// AsJSON renders the status Code response into a JSON string as []byte
 func (aboutResponse AboutResponse) AsJSON() []byte {
 	aboutResponse.ServerID = ID
 	aboutResponse.Version = Version
@@ -130,7 +130,7 @@ func (statusCodeResponse *StatusCodeResponse) withCode(code int) {
 	}
 }
 
-//AsJSON renders the status Code response into a JSON string as []byte
+// AsJSON renders the status Code response into a JSON string as []byte
 func (statusCodeResponse StatusCodeResponse) AsJSON() []byte {
 	statusCodeResponse.ServerID = ID
 	statusCodeResponse.Version = Version

--- a/abouthandler_test.go
+++ b/abouthandler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-//this testHandler binds the mock HTTP server to proxyHandler.
+// this testHandler binds the mock HTTP server to proxyHandler.
 type AboutHttpHandler struct{}
 
 func (t AboutHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/abouthandler_test.go
+++ b/abouthandler_test.go
@@ -24,7 +24,7 @@ func TestAboutHandlerAcceptEncodingIdentitySendsIdentity(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +36,7 @@ func TestAboutHandlerAcceptEncodingIdentitySendsIdentity(t *testing.T) {
 	}
 
 	want := "identity"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -54,7 +54,7 @@ func TestAboutHandlerAcceptEncodingNotSpecifiedSendsIdentity(t *testing.T) {
 		},
 	}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Del("Accept-Encoding")
+	req.Header.Del(acceptEncoding)
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +66,7 @@ func TestAboutHandlerAcceptEncodingNotSpecifiedSendsIdentity(t *testing.T) {
 	}
 
 	want := "identity"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -80,7 +80,7 @@ func TestAboutHandlerAcceptEncodingGzipSendsGzip(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set(acceptEncoding, "gzip")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -92,7 +92,7 @@ func TestAboutHandlerAcceptEncodingGzipSendsGzip(t *testing.T) {
 	}
 
 	want := "gzip"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -106,14 +106,14 @@ func TestAboutHandlerAcceptEncodingBrotliSendsBrotli(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "br")
+	req.Header.Set(acceptEncoding, "br")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := "br"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -127,7 +127,7 @@ func TestAboutHandlerAcceptEncodingDeflateSends406AsIdentity(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "deflate")
+	req.Header.Set(acceptEncoding, "deflate")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -140,7 +140,7 @@ func TestAboutHandlerAcceptEncodingDeflateSends406AsIdentity(t *testing.T) {
 	}
 
 	want := "identity"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
 	}

--- a/globaloptionshandler.go
+++ b/globaloptionshandler.go
@@ -1,0 +1,26 @@
+package j8a
+
+import "net/http"
+
+const allow = "Allow"
+
+func globalOptionsHandler(w http.ResponseWriter, r *http.Request) {
+	proxy := new(Proxy).
+		parseIncoming(r).
+		setOutgoing(w)
+
+	proxy.respondWith(200, "ok")
+	proxy.writeStandardResponseHeaders()
+	//send the allowable HTTP methods
+	for _, method := range httpLegalMethods {
+		w.Header().Add(allow, method)
+	}
+
+	//do we need this? there's no body
+	proxy.Dwn.Resp.ContentEncoding = EncIdentity
+	w.Header().Set(contentEncoding, string(proxy.Dwn.Resp.ContentEncoding))
+	proxy.setContentLengthHeader()
+	proxy.sendDownstreamStatusCodeHeader()
+
+	logHandledDownstreamRoundtrip(proxy)
+}

--- a/globaloptionshandler_test.go
+++ b/globaloptionshandler_test.go
@@ -1,0 +1,53 @@
+package j8a
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// this testHandler binds the mock HTTP server to proxyHandler.
+type GlobalOptionsHandler struct{}
+
+func (t GlobalOptionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	globalOptionsHandler(w, r)
+}
+
+func TestGlobalOptionsHandlerReturnsWithAcceptHeaders(t *testing.T) {
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, v := range a {
+			if v != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	Runner = mockRuntime()
+
+	server := httptest.NewServer(&GlobalOptionsHandler{})
+	defer server.Close()
+
+	c := &http.Client{}
+	req, _ := http.NewRequest("OPTIONS", server.URL, nil)
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resp.Header["Allow"]
+	want := httpLegalMethods
+	if !eq(want, got) {
+		t.Errorf("expected server global allowed HTTP methods, want %v, got %v", want, got)
+	}
+
+	want2 := "identity"
+	got2 := resp.Header["Content-Encoding"][0]
+	if got2 != want2 {
+		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want2, got2)
+	}
+}

--- a/globaloptionshandler_test.go
+++ b/globaloptionshandler_test.go
@@ -33,7 +33,7 @@ func TestGlobalOptionsHandlerReturnsWithAcceptHeaders(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("OPTIONS", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func TestGlobalOptionsHandlerReturnsWithAcceptHeaders(t *testing.T) {
 	}
 
 	want2 := "identity"
-	got2 := resp.Header["Content-Encoding"][0]
+	got2 := resp.Header[contentEncoding][0]
 	if got2 != want2 {
 		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want2, got2)
 	}

--- a/integration/headers/globaloptions_test.go
+++ b/integration/headers/globaloptions_test.go
@@ -1,0 +1,42 @@
+package headers
+
+import (
+	"github.com/simonmittag/j8a/integration"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestGlobalOptionsHandlerForAllowHeadersPresent(t *testing.T) {
+	//step 1 we connect to j8a with net.dial
+	c, err := net.Dial("tcp", ":8080")
+	if err != nil {
+		t.Errorf("unable to connect to j8a server for integration test, cause: %v", err)
+		return
+	}
+
+	//step 2 we send headers and terminate HTTP message.
+	integration.CheckWrite(t, c, "OPTIONS * HTTP/1.1\r\n")
+	integration.CheckWrite(t, c, "Host: localhost:8080\r\n")
+	integration.CheckWrite(t, c, "Accept: */*\r\n")
+	integration.CheckWrite(t, c, "\r\n")
+
+	//step 3 read response headers and check allow content
+	buf := make([]byte, 512)
+	b, err2 := c.Read(buf)
+	t.Logf("normal. j8a responded with %v bytes", b)
+	if err2 != nil || !strings.Contains(string(buf), "Allow") {
+		t.Errorf("test failure. Allow header not present")
+	} else {
+		t.Logf("normal. received response %s", string(buf))
+	}
+
+	want := []string{"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE", "POST", "CONNECT"}
+	for _, m := range want {
+		if !strings.Contains(string(buf), m) {
+			t.Errorf("expected server to allow %v, but not found as response header", m)
+		} else {
+			t.Logf("normal. response contains Allow header for method %v", m)
+		}
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -38,14 +38,14 @@ const (
 	Sep                   = " "
 )
 
-//RFC7231 4.2.1
+// RFC7231 4.2.1
 var httpSafeMethods []string = []string{"GET", "HEAD", "OPTIONS", "TRACE"}
 
-//RFC7231 4.2.2
+// RFC7231 4.2.2
 var httpIdempotentMethods []string = []string{"PUT", "DELETE"}
 var httpRepeatableMethods = append(httpSafeMethods, httpIdempotentMethods...)
 
-//RFC7231 4.3
+// RFC7231 4.3
 var httpLegalMethods []string = append(httpRepeatableMethods, []string{"POST", "CONNECT"}...)
 
 type ContentEncoding string
@@ -217,14 +217,14 @@ type Resp struct {
 	ContentEncoding ContentEncoding
 }
 
-//Up wraps upstream
+// Up wraps upstream
 type Up struct {
 	Atmpt  *Atmpt
 	Atmpts []Atmpt
 	Count  int
 }
 
-//Down wraps downstream exchange
+// Down wraps downstream exchange
 type Down struct {
 	Req            *http.Request
 	Resp           Resp
@@ -712,9 +712,12 @@ func (proxy *Proxy) setRoute(route *Route) {
 	proxy.Route = route
 }
 
-//RFC7230, section 3.3.2
+// RFC7230, section 3.3.2
 func (proxy *Proxy) setContentLengthHeader() {
-	proxy.Dwn.Resp.ContentLength = int64(len(*proxy.Dwn.Resp.Body))
+	proxy.Dwn.Resp.ContentLength = 0
+	if proxy.Dwn.Resp.Body != nil {
+		proxy.Dwn.Resp.ContentLength = int64(len(*proxy.Dwn.Resp.Body))
+	}
 
 	if te := proxy.Dwn.Resp.Writer.Header().Get(transferEncoding); len(te) != 0 ||
 		//we set 0 for status code 204 because of RFC7230, 4.3.7, see: https://tools.ietf.org/html/rfc7231#page-31
@@ -745,7 +748,7 @@ func (proxy *Proxy) pipeDownstreamResponse() {
 	proxy.Dwn.Resp.Writer.Write(*proxy.Dwn.Resp.Body)
 }
 
-//status Code must be last, no headers may be written after this one.
+// status Code must be last, no headers may be written after this one.
 func (proxy *Proxy) copyUpstreamStatusCodeHeader() {
 	proxy.respondWith(proxy.Up.Atmpt.StatusCode, "none")
 }
@@ -769,7 +772,7 @@ func (proxy *Proxy) hasLegalHTTPMethod() bool {
 	return false
 }
 
-//get bearer token from request. feed into lib. check signature. check expiry. return true || false.
+// get bearer token from request. feed into lib. check signature. check expiry. return true || false.
 func (proxy *Proxy) validateJwt() bool {
 	var token string = ""
 	var err error

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -15,7 +15,7 @@ var (
 	mockGetFunc func(uri string) (*http.Response, error)
 )
 
-//this Mock object wraps the httpClient and prevents actual outgoing HTTP requests.
+// this Mock object wraps the httpClient and prevents actual outgoing HTTP requests.
 type MockHttp struct{}
 
 func (m *MockHttp) Do(req *http.Request) (*http.Response, error) {
@@ -26,7 +26,7 @@ func (m *MockHttp) Get(uri string) (*http.Response, error) {
 	return mockGetFunc(uri)
 }
 
-//this testHandler binds the mock HTTP server to proxyHandler.
+// this testHandler binds the mock HTTP server to proxyHandler.
 type ProxyHttpHandler struct{}
 
 func (t ProxyHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +96,7 @@ func TestUpstreamGzipEncodingPassThrough(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"gzip"},
+				contentEncoding: []string{"gzip"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader(*Gzip([]byte(json)))),
 		}, nil
@@ -107,7 +107,7 @@ func TestUpstreamGzipEncodingPassThrough(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set(acceptEncoding, "gzip")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -119,7 +119,7 @@ func TestUpstreamGzipEncodingPassThrough(t *testing.T) {
 	}
 
 	want := "gzip"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -133,7 +133,7 @@ func TestUpstreamGzipEncodingPassThroughWhenBrotliRequestedDownstream(t *testing
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"gzip"},
+				contentEncoding: []string{"gzip"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader(*Gzip([]byte(json)))),
 		}, nil
@@ -144,7 +144,7 @@ func TestUpstreamGzipEncodingPassThroughWhenBrotliRequestedDownstream(t *testing
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "gzip, br")
+	req.Header.Set(acceptEncoding, "gzip, br")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +156,7 @@ func TestUpstreamGzipEncodingPassThroughWhenBrotliRequestedDownstream(t *testing
 	}
 
 	want := "gzip"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -181,7 +181,7 @@ func TestUpstreamServerHeaderNotCopied(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -203,7 +203,7 @@ func TestUpstreamIdentityEncodingPassThrough(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"identity"},
+				contentEncoding: []string{"identity"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -214,7 +214,7 @@ func TestUpstreamIdentityEncodingPassThrough(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +226,7 @@ func TestUpstreamIdentityEncodingPassThrough(t *testing.T) {
 	}
 
 	want := "identity"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -241,7 +241,7 @@ func TestContentNegotiationFailsWithBadAcceptEncoding(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"identity"},
+				contentEncoding: []string{"identity"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -252,7 +252,7 @@ func TestContentNegotiationFailsWithBadAcceptEncoding(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "uh-oh")
+	req.Header.Set(acceptEncoding, "uh-oh")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -279,7 +279,7 @@ func TestUpstreamCustomEncodingPassThroughWithIdentityAcceptEncodingAndVary(t *t
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"custom"},
+				contentEncoding: []string{"custom"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -290,7 +290,7 @@ func TestUpstreamCustomEncodingPassThroughWithIdentityAcceptEncodingAndVary(t *t
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -302,13 +302,13 @@ func TestUpstreamCustomEncodingPassThroughWithIdentityAcceptEncodingAndVary(t *t
 	}
 
 	want := "custom"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
 
 	vary := resp.Header.Get("Vary")
-	if "Accept-Encoding" != vary {
+	if acceptEncoding != vary {
 		t.Errorf("should have sent a vary header for accept encoding when changing content encoding")
 	}
 }
@@ -331,7 +331,7 @@ func TestUpstreamMissingContentEncodingIdentityThenGzipReEncoding(t *testing.T) 
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set(acceptEncoding, "gzip")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -343,7 +343,7 @@ func TestUpstreamMissingContentEncodingIdentityThenGzipReEncoding(t *testing.T) 
 	}
 
 	want := "gzip"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -358,7 +358,7 @@ func TestUpstreamGzipReEncoding(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"identity"},
+				contentEncoding: []string{"identity"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -369,7 +369,7 @@ func TestUpstreamGzipReEncoding(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set(acceptEncoding, "gzip")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -381,7 +381,7 @@ func TestUpstreamGzipReEncoding(t *testing.T) {
 	}
 
 	want := "gzip"
-	got := resp.Header["Content-Encoding"][0]
+	got := resp.Header[contentEncoding][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
 	}
@@ -397,7 +397,7 @@ func TestUpstreamBrotliReEncoding(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"identity"},
+				contentEncoding: []string{"identity"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -408,7 +408,7 @@ func TestUpstreamBrotliReEncoding(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "br")
+	req.Header.Set(acceptEncoding, "br")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -426,7 +426,7 @@ func TestUpstreamBrotliReEncoding(t *testing.T) {
 	}
 
 	want2 := "br"
-	got2 := resp.Header["Content-Encoding"][0]
+	got2 := resp.Header[contentEncoding][0]
 	if got2 != want2 {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want2, got2)
 	}
@@ -441,7 +441,7 @@ func TestUpstreamIncompatibleContentEncodingSendVaryHeader(t *testing.T) {
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"gzip"},
+				contentEncoding: []string{"gzip"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader(*Gzip([]byte(json)))),
 		}, nil
@@ -452,7 +452,7 @@ func TestUpstreamIncompatibleContentEncodingSendVaryHeader(t *testing.T) {
 
 	c := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)
-	req.Header.Set("Accept-Encoding", "identity")
+	req.Header.Set(acceptEncoding, "identity")
 	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -464,13 +464,13 @@ func TestUpstreamIncompatibleContentEncodingSendVaryHeader(t *testing.T) {
 	}
 
 	want := "gzip"
-	got := resp.Header.Get("Content-Encoding")
+	got := resp.Header.Get(contentEncoding)
 	if got != want {
 		t.Errorf("upstream should have sent gzip, got %v", got)
 	}
 
 	vary := resp.Header.Get("Vary")
-	if "Accept-Encoding" != vary {
+	if acceptEncoding != vary {
 		t.Errorf("should have sent a vary header for accept encoding when changing content encoding")
 	}
 }


### PR DESCRIPTION
- added global options handler in proxy logic. added flag to disable go 1.20's built-in handler.
- renamed responses to abouthandler.go
- unit test for globaloptionshandler with mock HTTP server returning allow headers
- unit test for globaloptionshandler with mock HTTP server returning allow headers
