### PR TITLE
313

### DIFF
--- a/integration/content/contentlength_test.go
+++ b/integration/content/contentlength_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 )
 
+func TestCONNECTContentLengthResponses(t *testing.T) {
+	MethodHasZeroContentLengthAndNoBody(t, "CONNECT", "http://localhost:8080/mse6/connect", "Identity")
+}
+
 func TestGETContentLengthResponses(t *testing.T) {
 	MethodHasContentLengthAndBody(t, "GET", "http://localhost:8080/about", "Identity")
 	MethodHasContentLengthAndBody(t, "GET", "http://localhost:8080/about", "identity")

--- a/integration/method/method_test.go
+++ b/integration/method/method_test.go
@@ -14,6 +14,11 @@ func TestHttpMethods(t *testing.T) {
 		responseCode int
 	}{
 		{
+			method:       "CONNECT",
+			url:          "/mse6/connect",
+			responseCode: 200,
+		},
+		{
 			method:       "GET",
 			url:          "/mse6/get",
 			responseCode: 200,

--- a/integration/method/method_test.go
+++ b/integration/method/method_test.go
@@ -1,0 +1,94 @@
+package method
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestHttpMethods(t *testing.T) {
+	tests := []struct {
+		method       string
+		url          string
+		responseCode int
+	}{
+		{
+			method:       "GET",
+			url:          "/mse6/get",
+			responseCode: 200,
+		},
+		{
+			method:       "HEAD",
+			url:          "/mse6/getorhead?cl=y",
+			responseCode: 200,
+		},
+		{
+			method:       "POST",
+			url:          "/mse6/post",
+			responseCode: 201,
+		},
+		{
+			method:       "PUT",
+			url:          "/mse6/put",
+			responseCode: 200,
+		},
+		{
+			method:       "OPTIONS",
+			url:          "/mse6/options?code=200",
+			responseCode: 200,
+		},
+		{
+			method:       "DELETE",
+			url:          "/mse6/delete",
+			responseCode: 204,
+		},
+		{
+			method:       "PATCH",
+			url:          "/mse6/patch",
+			responseCode: 200,
+		},
+		{
+			method:       "TRACE",
+			url:          "/mse6/trace",
+			responseCode: 200,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("TestWith"+test.method, func(t *testing.T) {
+			methodWithResponseCodeBody(t, test.method, test.url, test.responseCode)
+		})
+	}
+}
+
+func methodWithResponseCodeBody(t *testing.T, method string, url string, responseCode int) {
+	client := &http.Client{}
+
+	url = "http://localhost:8080" + url
+
+	var buf *bytes.Buffer
+	var req *http.Request
+	if method == "PUT" || method == "POST" || method == "PATCH" || method == "DELETE" {
+		jsonData := map[string]string{"scandi": "grind", "convex": "grind", "concave": "grind"}
+		jsonValue, _ := json.Marshal(jsonData)
+		buf = bytes.NewBuffer(jsonValue)
+		req, _ = http.NewRequest(method, url, buf)
+	} else {
+		req, _ = http.NewRequest(method, url, nil)
+	}
+
+	req.Header.Add("Accept-Encoding", "identity")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Errorf("error connecting to server for method %s, url %s, cause: %s", method, url, err)
+	}
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	gotCode := resp.StatusCode
+	if responseCode != gotCode {
+		t.Errorf("illegal response for method %s, url %s received %d want %d", method, url, gotCode, responseCode)
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -46,7 +46,7 @@ var httpIdempotentMethods []string = []string{"PUT", "DELETE"}
 var httpRepeatableMethods = append(httpSafeMethods, httpIdempotentMethods...)
 
 // RFC7231 4.3
-var httpLegalMethods []string = append(httpRepeatableMethods, []string{"POST", "CONNECT"}...)
+var httpLegalMethods []string = append(httpRepeatableMethods, []string{"POST", "PATCH", "CONNECT"}...)
 
 type ContentEncoding string
 


### PR DESCRIPTION
- added tests for various http methods and support for PATCH
- added tests for zero content length for CONNECT and testing for no body returned (upstream does this illegally, but J8a kills it).
