### PR TITLE
brand new Statehandler replaces "Boot" waitgroup we previously used for testing.

### DIFF
--- a/cmd/j8a/main.go
+++ b/cmd/j8a/main.go
@@ -15,7 +15,7 @@ import (
 type Mode uint8
 
 const (
-	Bootstrap Mode = 1 << iota
+	Loading Mode = 1 << iota
 	Server
 	Validate
 	Usage
@@ -23,7 +23,7 @@ const (
 )
 
 func main() {
-	mode := Bootstrap
+	mode := Loading
 
 	//trap sigkill and other aborts
 	go waitForSignal()
@@ -80,6 +80,7 @@ func printVersion() {
 
 func recovery() {
 	if r := recover(); r != nil {
+		j8a.ShutDown()
 		pid := os.Getpid()
 		log.WithLevel(zerolog.FatalLevel).
 			Int("pid", pid).

--- a/cmd/j8a/main.go
+++ b/cmd/j8a/main.go
@@ -60,7 +60,6 @@ func main() {
 	case Validate:
 		j8a.Validate()
 	case Server:
-		j8a.Boot.Add(1)
 		j8a.BootStrap()
 	case Usage:
 		printUsage()

--- a/config.go
+++ b/config.go
@@ -119,30 +119,9 @@ func (config Config) validateLogLevel() *Config {
 	logLevel := strings.ToUpper(config.LogLevel)
 	old := strings.ToUpper(zerolog.GlobalLevel().String())
 
-	const delay = time.Second * 3
 	if len(logLevel) > 0 && logLevel != old {
 		switch logLevel {
-		case "TRACE":
-			//TODO this should wait for Daemon state instead
-			time.AfterFunc(delay, func() {
-				log.Info().Msgf("resetting global log level to %v", logLevel)
-				zerolog.SetGlobalLevel(zerolog.TraceLevel)
-			})
-		case "DEBUG":
-			time.AfterFunc(delay, func() {
-				log.Info().Msgf("resetting global log level to %v", logLevel)
-				zerolog.SetGlobalLevel(zerolog.DebugLevel)
-			})
-		case "INFO":
-			time.AfterFunc(delay, func() {
-				log.Info().Msgf("resetting global log level to %v", logLevel)
-				zerolog.SetGlobalLevel(zerolog.InfoLevel)
-			})
-		case "WARN":
-			time.AfterFunc(delay, func() {
-				log.Info().Msgf("resetting global log level to %v", logLevel)
-				zerolog.SetGlobalLevel(zerolog.WarnLevel)
-			})
+		case "TRACE", "DEBUG", "INFO", "WARN":
 		default:
 			config.panic(fmt.Sprintf("invalid log level %v must be one of TRACE | DEBUG | INFO | WARN ", logLevel))
 		}

--- a/config.go
+++ b/config.go
@@ -123,6 +123,7 @@ func (config Config) validateLogLevel() *Config {
 	if len(logLevel) > 0 && logLevel != old {
 		switch logLevel {
 		case "TRACE":
+			//TODO this should wait for Daemon state instead
 			time.AfterFunc(delay, func() {
 				log.Info().Msgf("resetting global log level to %v", logLevel)
 				zerolog.SetGlobalLevel(zerolog.TraceLevel)

--- a/connectionwatcher.go
+++ b/connectionwatcher.go
@@ -1,0 +1,71 @@
+package j8a
+
+import (
+	"net"
+	"net/http"
+	"sync/atomic"
+)
+
+type ConnectionWatcher struct {
+	dwnOpenConns    int64
+	dwnMaxOpenConns int64
+	upOpenConns     int64
+	upMaxOpenConns  int64
+}
+
+// OnStateChange records open connections in response to connection
+// state changes. Set net/http Server.ConnState to this method
+// as value.
+func (cw *ConnectionWatcher) OnStateChange(conn net.Conn, state http.ConnState) {
+	switch state {
+	case http.StateNew:
+		cw.AddDwn(1)
+	case http.StateHijacked, http.StateClosed:
+		cw.AddDwn(-1)
+	}
+	cw.UpdateMaxDwn(cw.DwnCount())
+}
+
+// Count returns the number of connections at the time
+// the call.
+func (cw *ConnectionWatcher) DwnCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.dwnOpenConns))
+}
+
+func (cw *ConnectionWatcher) DwnMaxCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.dwnMaxOpenConns))
+}
+
+// Add adds c to the number of active connections.
+func (cw *ConnectionWatcher) AddDwn(c int64) {
+	atomic.AddInt64(&cw.dwnOpenConns, c)
+}
+
+// Sets the maximum number of active connections observed
+func (cw *ConnectionWatcher) UpdateMaxDwn(c uint64) {
+	if c > cw.DwnMaxCount() {
+		atomic.StoreInt64(&cw.dwnMaxOpenConns, int64(c))
+	}
+}
+
+func (cw *ConnectionWatcher) UpCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.upOpenConns))
+}
+
+func (cw *ConnectionWatcher) UpMaxCount() uint64 {
+	return uint64(atomic.LoadInt64(&cw.upMaxOpenConns))
+}
+
+func (cw *ConnectionWatcher) AddUp(c int64) {
+	atomic.AddInt64(&cw.upOpenConns, c)
+}
+
+func (cw *ConnectionWatcher) SetUp(c uint64) {
+	atomic.StoreInt64(&cw.upOpenConns, int64(c))
+}
+
+func (cw *ConnectionWatcher) UpdateMaxUp(c uint64) {
+	if c > cw.UpMaxCount() {
+		atomic.StoreInt64(&cw.upMaxOpenConns, int64(c))
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -26,63 +26,40 @@ func TestDefaultLogLevelInit(t *testing.T) {
 	}
 }
 
-func TestTraceLogLevelInit(t *testing.T) {
-	c := Config{
-		LogLevel: "trace",
+func TestLogLevelReset(t *testing.T) {
+	tests := []struct {
+		n string
+		l string
+	}{
+		{"trace", "trace"},
+		{"debug", "debug"},
+		{"info", "info"},
+		{"warn", "warn"},
 	}
-	initLogger()
-	c.validateLogLevel()
-	time.Sleep(time.Second * 4)
 
-	got := zerolog.GlobalLevel().String()
-	want := "trace"
-	if got != want {
-		t.Errorf("log level not properly initialised, got %v, want %v", got, want)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.n, func(t *testing.T) {
+			c := Config{
+				LogLevel: tt.l,
+			}
+			initLogger()
+			c.validateLogLevel()
 
-func TestDebugLogLevelInit(t *testing.T) {
-	c := Config{
-		LogLevel: "debug",
-	}
-	initLogger()
-	c.validateLogLevel()
-	time.Sleep(time.Second * 4)
+			Runner = &Runtime{
+				Config:       c,
+				StateHandler: NewStateHandler(),
+			}
+			Runner.StateHandler.setState(Daemon)
+			Runner.resetLogLevel()
 
-	got := zerolog.GlobalLevel().String()
-	want := "debug"
-	if got != want {
-		t.Errorf("log level not properly initialised, got %v, want %v", got, want)
-	}
-}
+			time.Sleep(time.Millisecond * 1000)
 
-func TestInfoLogLevelInit(t *testing.T) {
-	c := Config{
-		LogLevel: "INFO",
-	}
-	initLogger()
-	c.validateLogLevel()
-	time.Sleep(time.Second * 4)
-
-	got := zerolog.GlobalLevel().String()
-	want := "info"
-	if got != want {
-		t.Errorf("log level not properly initialised, got %v, want %v", got, want)
-	}
-}
-
-func TestWarnLogLevelInit(t *testing.T) {
-	c := Config{
-		LogLevel: "warn",
-	}
-	initLogger()
-	c.validateLogLevel()
-	time.Sleep(time.Second * 4)
-
-	got := zerolog.GlobalLevel().String()
-	want := "warn"
-	if got != want {
-		t.Errorf("log level not properly initialised, got %v, want %v", got, want)
+			got := zerolog.GlobalLevel().String()
+			want := tt.l
+			if got != want {
+				t.Errorf("log level not properly initialised, got %v, want %v", got, want)
+			}
+		})
 	}
 }
 

--- a/reloadablecert.go
+++ b/reloadablecert.go
@@ -1,0 +1,43 @@
+package j8a
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/rs/zerolog/log"
+	"sync"
+)
+
+type ReloadableCert struct {
+	Cert *tls.Certificate
+	mu   sync.Mutex
+	Init bool
+	//required to use runtime internally without global pointer for testing.
+	runtime *Runtime
+}
+
+func (r *ReloadableCert) GetCertificateFunc(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return r.Cert, nil
+}
+
+func (r *ReloadableCert) triggerInit() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Init = true
+
+	var cert tls.Certificate
+	var err error
+
+	c := []byte(r.runtime.Connection.Downstream.Tls.Cert)
+	k := []byte(r.runtime.Connection.Downstream.Tls.Key)
+
+	cert, err = tls.X509KeyPair(c, k)
+	if err == nil {
+		r.Cert = &cert
+		r.Cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	}
+	if err == nil {
+		log.Info().Msgf("TLS certificate #%v initialized", formatSerial(cert.Leaf.SerialNumber))
+	}
+	r.Init = false
+	return err
+}

--- a/server.go
+++ b/server.go
@@ -93,6 +93,16 @@ func BootStrap() {
 		startListening()
 }
 
+func ShutDown() {
+	if Runner != nil {
+		Runner.Config.LogLevel = "INFO"
+		//do this synchronous inline here. we want it before the next statement (setState)
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		log.Info().Msgf("resetting global log level to %v", Runner.Config.LogLevel)
+		Runner.StateHandler.setState(Shutdown)
+	}
+}
+
 func processConfig() *Config {
 	initLogger()
 
@@ -156,8 +166,8 @@ func (rt *Runtime) resetLogLevel() *Runtime {
 				zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
 			case "INFO":
-				log.Info().Msgf("resetting global log level to %v", logLevel)
 				zerolog.SetGlobalLevel(zerolog.InfoLevel)
+				log.Info().Msgf("resetting global log level to %v", logLevel)
 
 			case "WARN":
 				log.Info().Msgf("resetting global log level to %v", logLevel)
@@ -224,7 +234,6 @@ func (rt *Runtime) startListening() {
 
 	select {
 	case sig := <-err:
-		rt.StateHandler.setState(Shutdown)
 		log.Fatal().Err(sig).Msg(sig.Error())
 		panic(sig.Error())
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -12,9 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
-//takes 76μs to load a certificate that's way too long to do every incoming request.
+// takes 76μs to load a certificate that's way too long to do every incoming request.
 func BenchmarkLoadTlsCert(b *testing.B) {
 	certPem := "-----BEGIN CERTIFICATE-----\nMIIEkzCCAvugAwIBAgIRANiwkh9AuRgrvYh7Y5DtWIUwDQYJKoZIhvcNAQELBQAw\ngYExHjAcBgNVBAoTFW1rY2VydCBkZXZlbG9wbWVudCBDQTErMCkGA1UECwwic2lt\nb25taXR0YWdAdHJvb3BlciAoU2ltb24gTWl0dGFnKTEyMDAGA1UEAwwpbWtjZXJ0\nIHNpbW9ubWl0dGFnQHRyb29wZXIgKFNpbW9uIE1pdHRhZykwHhcNMTkwNjAxMDAw\nMDAwWhcNMzAwNzMwMDExNDU5WjBjMScwJQYDVQQKEx5ta2NlcnQgZGV2ZWxvcG1l\nbnQgY2VydGlmaWNhdGUxODA2BgNVBAsML3NpbW9ubWl0dGFnQE1hY0Jvb2stUHJv\nLTE2LmxvY2FsIChTaW1vbiBNaXR0YWcpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\nMIIBCgKCAQEAsCTQ9rLTQYjIlGF7EOrTJux8E514TUoAuQ0xo1NOSssptjmDyGhb\n8K7+A/TgdU/xlPMcJf22nNDQ2MpqpgHGlDcuXt3SmVrcsTeby1Pa81gxKp23a51B\n8xAoHoHwXVSWdiMWk3H/Jjv/dtYL1L180neewcWvK26ANUwlzWG6BW1QVUXXNdRo\ndmxQ1eg2S/qMBASFj6QjCsWWJiEfmz4PQpsP8q5IqCcX85BUqGO919JlE/eXEAgk\n9Yuh61/50n39B/sPC0mU5s6vH0SPCBvz1g8SiXa8jj3jCXxa/0ZsYtAVqPe5BoRP\nvK2q1sbKbJVr7EpmiOdKxKPHonRHasweGwIDAQABo4GiMIGfMA4GA1UdDwEB/wQE\nAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB8GA1UdIwQY\nMBaAFMNEcloV4jg+eonB5omuJvQXiqiRMEkGA1UdEQRCMECCDyouamFiYmF0ZXN0\nLmNvbYIKamFiYmEudGVzdIIJbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAA\nAAABMA0GCSqGSIb3DQEBCwUAA4IBgQDGI3EUWPKsEOqLCpnwSlFihu8n9+g4pV3/\njItYhUqMBz1v8TqV2zykkJUtlfNoxrp5OAg4CG0Xr1zhqjub3teKbsNKlRpV+h04\n4ncltpe66u4gg9RW+ww/f+J3C2yZRIX+brhDcTpdEMyfVoCV/5jeCxWf29MdFcLU\nBfgFdEp1oe3bK/dyZc8SbUlmizyumaDOaZACihz/DKsJ+lzRdy6c3UPQgC3r72oN\nLx/ccpnwdeumWFs+qYOjYfrCGFXaabokdtyit4XURFngxpnPUB9jHDvkI5+/eTaB\nSpdjJxE6x4mciyZSvshhu1v8j52+d9zUANs9+Y/v6EoCZ6byaaS4NAmTXdAWlnYb\nhIuRRsI4gIDhJWLrACBu1Osh7ZknaLNVMt5xo3TemCkVKud3NHGbycHTUoFBuHz/\nJOTQJ/Z1Ym3enpTAESZVcZTzS9gL62wfIfLcFvq+tVjoJZVJCcolP2fYn3U5lEiN\nvZvs72xp4sYEOa9zhvEs/yte9c6rkU0=\n-----END CERTIFICATE-----\n"
 	cAPem := "-----BEGIN CERTIFICATE-----\nMIIE0zCCAzugAwIBAgIQB2bsiI7SUtxu+HwBxuNtpDANBgkqhkiG9w0BAQsFADCB\ngTEeMBwGA1UEChMVbWtjZXJ0IGRldmVsb3BtZW50IENBMSswKQYDVQQLDCJzaW1v\nbm1pdHRhZ0B0cm9vcGVyIChTaW1vbiBNaXR0YWcpMTIwMAYDVQQDDClta2NlcnQg\nc2ltb25taXR0YWdAdHJvb3BlciAoU2ltb24gTWl0dGFnKTAeFw0yMDA1MDEyMTE2\nNDNaFw0zMDA1MDEyMTE2NDNaMIGBMR4wHAYDVQQKExVta2NlcnQgZGV2ZWxvcG1l\nbnQgQ0ExKzApBgNVBAsMInNpbW9ubWl0dGFnQHRyb29wZXIgKFNpbW9uIE1pdHRh\nZykxMjAwBgNVBAMMKW1rY2VydCBzaW1vbm1pdHRhZ0B0cm9vcGVyIChTaW1vbiBN\naXR0YWcpMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzivKfp5OiWpT\n362cVgbw9DBqwMP0pO32aP79Y4UYeAxCfaWQDdqQEatBdraShtZcvUX8vZ9jvgHE\noGMGSJb/DIVRxIDfhdvhh4qGQgbbSLwDkfLJTkpGMdONa/5yDC54fNZjF095YZn7\niPmsFbvYUfTwpM8qrP+jZzobByrTO4rG3Ps080gIR08RCA0E+uLg58rTpnsdBKZ0\nK2uuE4B4lVAs2AeS4KPMrH/rnCjSZz4KRwnaGqh+wiAjO0PHAfrbrhNsFB6P1/Zk\nCqzclj3TXdkMDaXhSvt0qJPEpNIPQMkvj9GROom7hExZUT7t7LPOZwODtiR2VjM3\nDDehfLqpNPRrxU3aOR7b4lFVtEL1+9NXKc3rnR5T2xPVVvBxx8FqYAxFmQtkGqpA\nYlRxImBONBreIr5/fdkr5xqd/S0s1pb8ubuK7x5COfqf0Mv++j+UjMptBQ3kYvOh\ntNrbnEI1q/7kvHNB8ETtJ4hqXikl9EHMYWdOo4nyGd4P8jo9jmGVAgMBAAGjRTBD\nMA4GA1UdDwEB/wQEAwICBDASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTD\nRHJaFeI4PnqJweaJrib0F4qokTANBgkqhkiG9w0BAQsFAAOCAYEAb+K3HO2AlDed\nS2yT7GnxD75Hcjnv1tMvMIlh1EOmRMHrzbsi7jv3Z7SDe2R5s1qRku3nxbVWj8i8\noRBi5GeRE+q/HkVloi4WPmgFGxUUbkWszAFSSGN5TAs72e5sCG/wMyEa0Gj8cOO1\ndK5SH3thP8+OjSpgQXToYfOimILlk7Hj7EgKE5Y8YX8UV+41LhGkzeK2UX9dBZn1\nof9qBc0dAQVlAA/O3dOgXorgiDbNT38cjignWEwVYzjeuJCYB91Ixf0CfHJZKHZR\nZCdIAHTJqW1tx7vsbrcl0PVAMgm+rkHLL0Dh9cp4fvONXWygVSjbqKM1s8UI9bFA\nbWU5Z3MhEn25wZCXLQDIq0uC+FwCxyS9e/exL4wmYpCLmRKVCp2gUa78Rlr/FJNa\nH9kfvP41Ya+fLzDWNKAlYQgizpZJmZuhPZu7O6n0UusaI+0WTKblCFUQJkx4aKEv\nio8QmLzoedmvVpO9Zp44Lyabmc7VnjoYTOcZczx4ECwEdKH/jswc\n-----END CERTIFICATE-----\n"
@@ -102,13 +103,43 @@ func TestHandlerDelegate_ServeHTTP_Acme(t *testing.T) {
 }
 
 func TestServerBootStrap(t *testing.T) {
-	setupJ8a()
+	ConfigFile = "./j8acfg.yml"
+	before := time.Now()
+
+	//we need to nuke the other Runners that may have been created by previous unit tests
+	Runner = nil
+
+	//this triggers the Bootstrap process and results in the StateHandler to go through Bootstrap, then into Daemon state
+	go BootStrap()
+
+	//we need this because Runner is initialised by the goroutine above
+	for {
+		if Runner != nil && Runner.StateHandler != nil {
+			break
+		} else {
+			time.Sleep(time.Millisecond * 100)
+		}
+	}
+
+	//this blocks until we reach Daemon state or dies after 30 seconds
+	testTimeOutSeconds := 10
+	Runner.StateHandler.waitState(Daemon, testTimeOutSeconds)
+	delta := time.Now().Sub(before)
+
+	if delta > time.Second*time.Duration(testTimeOutSeconds) {
+		t.Errorf("should not have timed out waiting for Daemon state")
+	} else {
+		t.Logf("normal. returned from StateHandler wait state in %v", delta)
+	}
+
 	resp, err := http.Get("http://localhost:8080/about")
 	if resp != nil && resp.StatusCode != 200 {
 		t.Errorf("server does not return ok status response after starting, want 200, got %v", resp.StatusCode)
 	}
 	if err != nil {
 		t.Errorf("GET req to /about returned error, %v", err)
+	} else {
+		t.Logf("normal. GET req against Bootstrapped server")
 	}
 }
 
@@ -138,7 +169,7 @@ func TestZerologAdapter_Write(t *testing.T) {
 	zla.Write([]byte("i'm a log line from 127.0.0.1 there's no place like it"))
 }
 
-//test this on windows. Go doco says it should work:
+// test this on windows. Go doco says it should work:
 func TestServerInitDotDir(t *testing.T) {
 	Runner := mockRuntime()
 	Runner.initCacheDir()
@@ -200,13 +231,6 @@ func TestConnectionWatcher_OnStateChange(t *testing.T) {
 	if cw.DwnMaxCount() != 2 {
 		t.Error("maxcount should still be 2")
 	}
-}
-
-func setupJ8a() {
-	ConfigFile = "./j8acfg.yml"
-	Boot.Add(1)
-	go BootStrap()
-	Boot.Wait()
 }
 
 func mockRequest() http.Request {

--- a/server_test.go
+++ b/server_test.go
@@ -121,7 +121,7 @@ func TestServerBootStrap(t *testing.T) {
 		}
 	}
 
-	//this blocks until we reach Daemon state or dies after 30 seconds
+	//this blocks until we reach Daemon state or dies after 10 seconds
 	testTimeOutSeconds := 10
 	Runner.StateHandler.waitState(Daemon, testTimeOutSeconds)
 	delta := time.Now().Sub(before)

--- a/state.go
+++ b/state.go
@@ -1,0 +1,65 @@
+package j8a
+
+import (
+	"math"
+	"time"
+)
+
+type State string
+
+const (
+	Bootstrap State = "Bootstrap"
+	Daemon    State = "Daemon"
+	Shutdown  State = "Shutdown"
+)
+
+func (s State) Lesser(t State) bool {
+	if s == Bootstrap && (t == Daemon || t == Shutdown) {
+		return true
+	}
+	if s == Daemon && t == Shutdown {
+		return true
+	}
+	return false
+}
+
+type StateHandler struct {
+	Current State
+	Update  chan State
+}
+
+func NewStateHandler() *StateHandler {
+	return &StateHandler{
+		Current: Bootstrap,
+		Update:  make(chan State),
+	}
+}
+
+func (sh *StateHandler) waitState(s State, timeoutSeconds ...int) {
+	if s == sh.Current || s.Lesser(sh.Current) {
+		return
+	} else {
+		to := time.Duration(math.MaxInt64)
+		if len(timeoutSeconds) > 0 {
+			to = time.Second * time.Duration(timeoutSeconds[0])
+		}
+		for {
+			select {
+			case ev := <-sh.Update:
+				if s == ev || s.Lesser(ev) {
+					return
+				}
+			case <-time.After(to):
+				return
+			}
+		}
+	}
+}
+
+func (sh *StateHandler) setState(s State) {
+	sh.Current = s
+	//needs to be async else setState blocks
+	go func() {
+		sh.Update <- s
+	}()
+}

--- a/state.go
+++ b/state.go
@@ -57,9 +57,12 @@ func (sh *StateHandler) waitState(s State, timeoutSeconds ...int) {
 }
 
 func (sh *StateHandler) setState(s State) {
-	sh.Current = s
-	//needs to be async else setState blocks
-	go func() {
-		sh.Update <- s
-	}()
+	// == matters because we may want to retrigger the state for waiting goroutines.
+	if sh.Current == s || sh.Current.Lesser(s) {
+		sh.Current = s
+		//needs to be async else setState blocks
+		go func() {
+			sh.Update <- s
+		}()
+	}
 }

--- a/state.go
+++ b/state.go
@@ -1,6 +1,9 @@
 package j8a
 
 import (
+	"fmt"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"math"
 	"time"
 )
@@ -60,6 +63,13 @@ func (sh *StateHandler) setState(s State) {
 	// == matters because we may want to retrigger the state for waiting goroutines.
 	if sh.Current == s || sh.Current.Lesser(s) {
 		sh.Current = s
+
+		msg := fmt.Sprintf("server state now %v", sh.Current)
+		if s == Shutdown {
+			log.WithLevel(zerolog.FatalLevel).Msg(msg)
+		} else {
+			log.Info().Msg(msg)
+		}
 		//needs to be async else setState blocks
 		go func() {
 			sh.Update <- s

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,74 @@
+package j8a
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStateLesser(t *testing.T) {
+	tests := []struct {
+		n string
+		a State
+		b State
+		v bool
+	}{
+		{n: "Bootstrap not lesser Bootstrap", a: Bootstrap, b: Bootstrap, v: false},
+		{n: "Bootstrap lesser Daemon", a: Bootstrap, b: Daemon, v: true},
+		{n: "Bootstrap lesser Shutdown", a: Bootstrap, b: Shutdown, v: true},
+		{n: "Daemon not lesser Bootstrap", a: Daemon, b: Bootstrap, v: false},
+		{n: "Daemon not lesser Daemon", a: Daemon, b: Daemon, v: false},
+		{n: "Daemon lesser Shutdown", a: Daemon, b: Shutdown, v: true},
+		{n: "Shutdown not lesser Daemon", a: Shutdown, b: Daemon, v: false},
+		{n: "Shutdown not lesser Bootstrap", a: Shutdown, b: Bootstrap, v: false},
+		{n: "Shutdown not lesser Shutdown", a: Shutdown, b: Shutdown, v: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.n, func(t *testing.T) {
+			want := tt.v
+			got := tt.a.Lesser(tt.b)
+			if want != got {
+				t.Errorf("%v failed, want %v got %v", tt.n, want, got)
+			}
+		})
+	}
+}
+
+// Tests pass under the timeout threshold if a status is lesser or equal the current status.
+// results greater the treshold means the StateHandler would otherwise wait indefinitely for the status.
+func TestStateHandlerWaitForStatus(t *testing.T) {
+	tests := []struct {
+		n            string
+		current      State
+		waitingFor   State
+		delaySeconds int
+		greater      bool
+	}{
+		{"Bootstrap waiting for Bootstrap", Bootstrap, Bootstrap, 1, false},
+		{"Bootstrap waiting for Daemon", Bootstrap, Daemon, 1, true},
+		{"Bootstrap waiting for Shutdown", Bootstrap, Shutdown, 1, true},
+		{"Daemon waiting for Bootstrap", Daemon, Bootstrap, 1, false},
+		{"Daemon waiting for Daemon", Daemon, Daemon, 1, false},
+		{"Daemon waiting for Shutdown", Daemon, Shutdown, 1, true},
+		{"Shutdown waiting for Bootstrap", Shutdown, Bootstrap, 1, false},
+		{"Shutdown waiting for Daemon", Shutdown, Daemon, 1, false},
+		{"Shutdown waiting for Shutdown", Shutdown, Shutdown, 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.n, func(t *testing.T) {
+			sh := NewStateHandler()
+			//TODO this blocks
+			sh.setState(tt.current)
+
+			before := time.Now()
+			sh.waitState(tt.waitingFor, tt.delaySeconds)
+			after := time.Now().Sub(before)
+			if after > time.Second*time.Duration(tt.delaySeconds) == tt.greater {
+				t.Logf("normal. current status %v waiting for %v delay %v", tt.current, tt.waitingFor, after)
+			} else {
+				t.Errorf("current status %v waiting for %v delay %v", tt.current, tt.waitingFor, after)
+			}
+		})
+	}
+}


### PR DESCRIPTION
the StateHandler transitions from Bootstrap to Daemon to Shutdown.

Use the wait method to park your client behind a status. Wait has a variadic timeout parameter which is mainly for unit testing purposes.
