### PR TITLE
356

### DIFF
--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -63,7 +63,9 @@ func PerformJ8aTest(t *testing.T, testMethod string, wantUpstreamWaitSeconds int
 		client = &http.Client{}
 	}
 
-	resp, err := client.Get(fmt.Sprintf("%s://localhost:%d/mse6%s?wait=%d", scheme, serverPort, testMethod, wantUpstreamWaitSeconds))
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s://localhost:%d/mse6%s?wait=%d", scheme, serverPort, testMethod, wantUpstreamWaitSeconds), nil)
+	req.Header.Set("X-REQUEST-INFO", "true")
+	resp, err := client.Do(req)
 	gotTotalWait := time.Since(start)
 
 	if err != nil {

--- a/proxyhandler.go
+++ b/proxyhandler.go
@@ -237,6 +237,8 @@ func performUpstreamRequest(proxy *Proxy) (*http.Response, error) {
 			!proxy.Up.Atmpts[attemptIndex].AbortedFlag &&
 			!proxy.Dwn.AbortedFlag {
 			close(proxy.Up.Atmpts[attemptIndex].CompleteHeader)
+		} else {
+			panic(upstreamReqAborted)
 		}
 	}()
 
@@ -345,6 +347,8 @@ func parseUpstreamResponse(upstreamResponse *http.Response, proxy *Proxy) ([]byt
 			!proxy.Up.Atmpt.AbortedFlag &&
 			!proxy.Dwn.AbortedFlag {
 			close(proxy.Up.Atmpts[attemptIndex].CompleteBody)
+		} else {
+			panic(upstreamResParseAbort)
 		}
 	}()
 

--- a/proxyhandler.go
+++ b/proxyhandler.go
@@ -225,7 +225,7 @@ func performUpstreamRequest(proxy *Proxy) (*http.Response, error) {
 						//ignore
 					}
 				}()
-				proxy.Up.Atmpt.CancelFunc()
+				proxy.Up.Atmpts[attemptIndex].CancelFunc()
 			}
 		}()
 
@@ -325,7 +325,8 @@ func parseUpstreamResponse(upstreamResponse *http.Response, proxy *Proxy) ([]byt
 						//ignore
 					}
 				}()
-				proxy.Up.Atmpt.CancelFunc()
+				//this matters because current Up.Atmpt may have moved on
+				proxy.Up.Atmpts[attemptIndex].CancelFunc()
 			}
 		}()
 

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -641,6 +641,7 @@ func TestParseUpstreamResponseWithNilResponse(t *testing.T) {
 	Runner.Connection.Upstream.MaxAttempts = 1
 
 	p := mockProxy(make([]byte, 1), "", "/", "", "/", "", "")
+
 	_, e := parseUpstreamResponse(nil, &p)
 	if e == nil {
 		t.Errorf("no response error for nil http request")


### PR DESCRIPTION
- panic during unsuccessful upstream events, now handled by wrapper, early exit of goroutines
- added test header
- fixed race condition bug where we were not cancelling the right cancelfunc()
- better mockProxy Method
